### PR TITLE
feat: Implement user profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,26 @@ This application now includes a fully functional blog where users can share thei
     *   `/blog/delete/<int:post_id>`: (POST)
         *   Requires login and that the logged-in user is the author of the post.
         *   Deletes the specified blog post after a confirmation.
+
+### User Profile Page
+
+This feature provides a dedicated page for each user, showcasing their activity and contributions to the application.
+
+*   **Purpose**: To display user-specific information, including their blog posts and uploaded images, creating a personalized space for each user.
+*   **Route**: `/user/<username>` (e.g., `/user/demo`)
+*   **Information Displayed**:
+    *   **Username**: The name of the user whose profile is being viewed.
+    *   **User's Blog Posts**:
+        *   A list of blog posts authored by the user.
+        *   Each post title links to the full post view (`/blog/post/<id>`).
+        *   The timestamp of when the post was created is also displayed.
+        *   If the user has not created any posts, a message like "This user has not created any posts yet." is shown.
+    *   **User's Uploaded Images**:
+        *   A gallery of images uploaded by the user.
+        *   Images are displayed in a grid format.
+        *   If the user has not uploaded any images, a message like "This user has not uploaded any images yet." is shown.
+*   **Flask Functionalities Demonstrated**:
+    *   **Dynamic Content Generation**: The content of the profile page is dynamically generated based on the `username` parameter in the URL and the associated user data.
+    *   **Data Aggregation**: Information (blog posts, uploaded images) is filtered and aggregated specifically for the viewed user.
+    *   **User-Specific Views**: Enhances the application by providing views tailored to individual users, improving personalization.
+    *   **Data Structures for User Association**: User data (like associated image filenames and blog post IDs) is managed within the `users` dictionary in `app.py`.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,15 +1,11 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hello, World!</title>
-</head>
-<body>
+{% extends "base.html" %}
+
+{% block title %}Home Page{% endblock %}
+
+{% block content %}
     <h1 class="page-title">Hello, World!</h1>
     <div class="content-box">
         <p>This is the home page of our awesome Flask application.</p>
         <p>We are demonstrating how static files (like CSS) are served.</p>
     </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -3,9 +3,36 @@
 {% block title %}User Profile - {{ username }}{% endblock %}
 
 {% block content %}
-    <h2 class="page-title">Hello, {{ username }}!</h2>
+    <h2 class="page-title">{{ username }}'s Profile</h2>
+
     <div class="content-box">
-        <p>This is your user profile page.</p>
-        <p>The styling here comes from <code>static/style.css</code> as well.</p>
+        <h3>User's Blog Posts</h3>
+        {% if posts %}
+            <ul>
+                {% for post in posts %}
+                    <li>
+                        <a href="{{ url_for('view_post', post_id=post.id) }}">{{ post.title }}</a>
+                        <span class="text-muted"> - {{ post.timestamp }}</span>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p>This user has not created any posts yet.</p>
+        {% endif %}
+    </div>
+
+    <div class="content-box">
+        <h3>User's Uploaded Images</h3>
+        {% if user_images %}
+            <div class="gallery-grid">
+                {% for image_filename in user_images %}
+                    <div class="gallery-item">
+                        <img src="{{ url_for('uploaded_file', filename=image_filename) }}" alt="User Image {{ image_filename }}" style="max-width: 200px; max-height: 200px; margin: 5px;">
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <p>This user has not uploaded any images yet.</p>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
This commit introduces a new user profile page accessible via `/user/<username>`.

The user profile page displays:
- Your username.
- A list of blog posts authored by you, with titles linking to the full post and timestamps.
- A gallery of images uploaded by you.
- Appropriate messages if you have no blog posts or uploaded images.

To support this feature, the following changes were made:
- The user data structure in `app.py` was updated to store lists of `uploaded_images` and `blog_post_ids` for each user.
- The registration process now initializes these fields for new users.
- Image upload and blog post creation functionalities were updated to associate the content with the logged-in user.
- The `user.html` template was created/updated to render this information.
- New tests were added for the user profile functionality.
- Existing tests were reviewed and fixed, including an issue with decorator order for protected routes.
- The `README.md` file has been updated to document this new feature.