### PR TITLE
feat: Implement post liking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,23 @@ To further enhance interactivity, the blog now features real-time comment notifi
 *   **Instant Updates**: When a user submits a comment on a blog post, other users currently viewing the same post will see the new comment appear instantly on their page without needing to manually refresh.
 *   **Technology**: This is implemented using Flask-SocketIO, enabling bidirectional real-time communication between the server and clients (browsers).
 *   **Enhanced Engagement**: This feature makes discussions more dynamic and engaging, as users can see new contributions as they happen.
+
+### Post Liking
+
+Users can now interact with blog posts by liking or unliking them, providing a simple way to show appreciation or engagement.
+
+*   **Functionality**:
+    *   Authenticated (logged-in) users can "like" a blog post. If they have already liked a post, they can "unlike" it.
+    *   Users can only like a specific post once. Attempting to like an already liked post will not change the like count. Similarly, unliking is only possible if the post was previously liked by the user.
+    *   The total number of likes for each post is displayed on the main blog listing page (`/blog`) and on the individual post view page (`/blog/post/<int:post_id>`).
+*   **User Interface**:
+    *   On the individual post page, logged-in users will see a "Like" button. If they have already liked the post, this button will change to "Unlike".
+    *   Users who are not logged in can see the like counts but will not see the Like/Unlike buttons.
+*   **Routes for Like/Unlike Actions**:
+    *   `/blog/post/<int:post_id>/like` (POST): Allows a logged-in user to like a specific post.
+    *   `/blog/post/<int:post_id>/unlike` (POST): Allows a logged-in user to unlike a post they had previously liked.
+*   **Flask Functionalities Demonstrated**:
+    *   Further practice with user session management and authentication checks.
+    *   Updating data models (incrementing/decrementing like counts, tracking user likes).
+    *   Conditional rendering in Jinja templates to display different buttons ("Like" or "Unlike") based on application state.
+    *   Handling POST requests for actions that modify data.

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -20,6 +20,7 @@
           {% if post.last_edited %}
             (Edited: {{ post.last_edited }})
           {% endif %}
+          | {{ post.likes }} like(s)
         </small></p>
         <p>{{ post.content[:200] }}... <a href="{{ url_for('view_post', post_id=post.id) }}">Read More</a>
         {% if session.logged_in and session.username == post.author_username %}

--- a/templates/view_post.html
+++ b/templates/view_post.html
@@ -15,6 +15,21 @@
     <p><small>By {{ post.author_username }} on {{ post.timestamp }}</small></p>
     <p>{{ post.content | safe }}</p> {# Assuming content is safe or will be sanitized later #}
 
+    <div style="margin-top: 15px; margin-bottom: 15px;">
+        <p>{{ post.likes }} like(s)</p>
+        {% if session.logged_in %}
+            {% if user_has_liked %}
+                <form action="{{ url_for('unlike_post', post_id=post.id) }}" method="POST" style="display: inline;">
+                    <button type="submit" class="btn btn-secondary btn-sm">Unlike</button>
+                </form>
+            {% else %}
+                <form action="{{ url_for('like_post', post_id=post.id) }}" method="POST" style="display: inline;">
+                    <button type="submit" class="btn btn-primary btn-sm">Like</button>
+                </form>
+            {% endif %}
+        {% endif %}
+    </div>
+
     {% if session.logged_in and session.username == post.author_username %}
     <hr>
     <a href="{{ url_for('edit_post', post_id=post.id) }}" class="btn btn-secondary" style="margin-top: 10px; margin-right: 5px;">Edit Post</a>


### PR DESCRIPTION
This commit introduces a new feature allowing you to like and unlike blog posts.

Key changes:
- Modified `app.py`:
    - Added a 'likes' counter to the blog post data structure.
    - Introduced a `post_likes` dictionary to track which users liked which posts, preventing multiple likes from the same user on a single post.
    - Implemented new POST routes:
        - `/blog/post/<int:post_id>/like`: Handles liking a post.
        - `/blog/post/<int:post_id>/unlike`: Handles unliking a post.
    - Updated the `view_post` route to pass like status to the template.
- Updated Templates:
    - `templates/view_post.html`: Displays the total likes for a post and shows conditional "Like" or "Unlike" buttons for logged-in users.
    - `templates/blog.html`: Displays the like count for each post in the list view.
- Added Tests:
    - New test class `TestLikeUnlikeFeatures` in `tests/test_app.py` covers: - Authentication checks for like/unlike actions. - Successful liking and unliking of posts. - Edge cases like liking non-existent posts or already liked posts. - Correct display of like counts and buttons in templates.
- Updated Documentation:
    - `README.md` now includes a new "Post Liking" section detailing the feature, its usage, and the associated routes.