### PR TITLE
feat: Implement private messaging feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,38 @@ Users can now interact with blog posts by liking or unliking them, providing a s
     *   Updating data models (incrementing/decrementing like counts, tracking user likes).
     *   Conditional rendering in Jinja templates to display different buttons ("Like" or "Unlike") based on application state.
     *   Handling POST requests for actions that modify data.
+
+## Private Messaging
+
+This application now supports private messaging between registered users, allowing for direct, one-on-one communication.
+
+*   **Purpose**: Enables users to send and receive private messages, fostering a more interactive and personal experience on the platform.
+*   **Authentication**: This feature is exclusively available to logged-in users. Users must be authenticated to send messages, view their inbox, and participate in conversations.
+
+*   **Flask Functionalities Demonstrated**:
+    *   **User-to-User Interaction**: Manages direct communication and data relationships between different users.
+    *   **Dynamic Content Generation**: The inbox and conversation views are dynamically generated based on the logged-in user's messages.
+    *   **Form Handling**: Uses forms for composing and sending messages.
+    *   **Session Management**: Leverages user sessions to identify the sender and receiver, and to authorize access to messages.
+    *   **Data Persistence**: Messages are stored in-memory (similar to blog posts and comments) and include sender, receiver, content, timestamp, and a read status.
+    *   **Conditional Logic**: Used extensively in templates and views to display appropriate information (e.g., unread message counts, user-specific conversation views).
+
+*   **Routes & Usage**:
+    *   `/messages/inbox`: (GET)
+        *   Requires login.
+        *   Displays the logged-in user's message inbox.
+        *   Lists all conversations the user is part of, ordered by the most recent message.
+        *   For each conversation, it shows the other user, a snippet of the last message, the timestamp of the last message, and a count of unread messages in that conversation.
+        *   Each conversation entry links to the full conversation view.
+    *   `/messages/conversation/<username>`: (GET)
+        *   Requires login.
+        *   Displays the full message history between the logged-in user and the specified `<username>`.
+        *   Messages are displayed in chronological order.
+        *   When a user opens a conversation, any unread messages they received in that conversation are automatically marked as "read".
+        *   Includes a reply form at the bottom to quickly send another message to the conversation partner.
+    *   `/messages/send/<receiver_username>`: (GET/POST)
+        *   Requires login.
+        *   `GET`: Displays a form to compose a new message to `<receiver_username>`. This is typically accessed via the "Send Message" button on a user's profile or the reply form in a conversation.
+        *   `POST`: Processes the submitted message content and sends it to `<receiver_username>`. Redirects to the conversation view with that user upon successful sending.
+    *   `/user/<username>`:
+        *   User profile pages now feature a "Send Message" button if the viewer is logged in and is not viewing their own profile. This button links directly to the `/messages/send/<username>` route for the profile owner.

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,7 @@
                 <li><a href="{{ url_for('upload_image') }}">Upload Image</a></li>
                 <li><a href="{{ url_for('blog') }}">Blog</a></li>
                 {% if session['logged_in'] %}
+                  <li><a href="{{ url_for('inbox') }}">Inbox</a></li>
                   <li><a href="{{ url_for('create_post') }}">Create Post</a></li>
                   <li><span>Logged in as {{ session['username'] }}</span></li>
                   <li><a href="{{ url_for('logout') }}">Logout</a></li>

--- a/templates/conversation.html
+++ b/templates/conversation.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}Conversation with {{ conversation_partner }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Conversation with {{ conversation_partner }}</h2>
+    <hr>
+
+    <div class="messages-container mb-4" style="max-height: 400px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; border-radius: 5px;">
+        {% if messages_list %}
+            {% for message in messages_list %}
+                <div class="message mb-2 p-2 rounded {% if message.sender_username == session['username'] %}bg-light text-end{% else %}bg-secondary text-white{% endif %}">
+                    <p class="mb-0"><strong>{{ message.sender_username }}</strong>: {{ message.content }}</p>
+                    <small class="text-muted">{{ message.timestamp }} {% if message.sender_username == session['username'] and message.is_read %} (Read){% endif %}</small>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p>No messages yet. Start the conversation!</p>
+        {% endif %}
+    </div>
+
+    <h4>Reply to {{ conversation_partner }}</h4>
+    <form method="POST" action="{{ url_for('send_message', receiver_username=conversation_partner) }}">
+        <div class="mb-3">
+            <label for="content" class="form-label">Your Message:</label>
+            <textarea class="form-control" id="content" name="content" rows="3" required></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Send Reply</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/inbox.html
+++ b/templates/inbox.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}My Messages{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>My Messages</h2>
+    <hr>
+
+    {% if inbox_items %}
+        <div class="list-group">
+            {% for item in inbox_items %}
+                <a href="{{ url_for('view_conversation', username=item.username) }}" class="list-group-item list-group-item-action {% if item.unread_count > 0 %}list-group-item-primary font-weight-bold{% endif %}">
+                    <div class="d-flex w-100 justify-content-between">
+                        <h5 class="mb-1">Conversation with: {{ item.username }}</h5>
+                        <small>{{ item.last_message_display_timestamp }}</small>
+                    </div>
+                    <p class="mb-1">{{ item.last_message_snippet }}</p>
+                    {% if item.unread_count > 0 %}
+                        <span class="badge bg-danger rounded-pill">{{ item.unread_count }} Unread</span>
+                    {% endif %}
+                </a>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p>You have no messages.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/send_message.html
+++ b/templates/send_message.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Send Message to {{ receiver_username }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Send Message to {{ receiver_username }}</h2>
+    <hr>
+    <form method="POST" action="{{ url_for('send_message', receiver_username=receiver_username) }}">
+        <div class="mb-3">
+            <label for="content" class="form-label">Your Message:</label>
+            <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Send Message</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -5,6 +5,12 @@
 {% block content %}
     <h2 class="page-title">{{ username }}'s Profile</h2>
 
+    {% if session['logged_in'] and session['username'] != username %}
+        <div class="mb-3">
+            <a href="{{ url_for('send_message', receiver_username=username) }}" class="btn btn-primary">Send Message to {{ username }}</a>
+        </div>
+    {% endif %}
+
     <div class="content-box">
         <h3>User's Blog Posts</h3>
         {% if posts %}


### PR DESCRIPTION
This commit introduces a private messaging system allowing you to send and receive messages.

Key functionalities include:
- You can send private messages to other registered users.
- An inbox view (/messages/inbox) lists all conversations, showing the last message snippet, timestamp, and unread message count.
- A conversation view (/messages/conversation/<username>) displays the full message history between two users and marks messages as read upon viewing.
- You can reply directly from the conversation view.
- A "Send Message" button is available on user profile pages.
- The feature is protected by login requirements.

Data structures for messages have been added to app.py, and corresponding HTML templates (send_message.html, conversation.html, inbox.html) have been created. The base template and user profile template were updated for navigation and interaction.

The README.md has been updated to document this new feature.

Basic unit tests have been added to cover sending messages, viewing conversations and inbox, access control, and UI elements related to messaging.