### PR TITLE
feat: Implement real-time comment notifications for post authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ To further enhance interactivity, the blog now features real-time comment notifi
 *   **Technology**: This is implemented using Flask-SocketIO, enabling bidirectional real-time communication between the server and clients (browsers).
 *   **Enhanced Engagement**: This feature makes discussions more dynamic and engaging, as users can see new contributions as they happen.
 
+### Author Comment Notifications
+
+*   **Targeted Alerts**: Post authors receive instant, targeted notifications when another user comments on one of their posts. This ensures authors are promptly informed of new interactions with their content.
+*   **Implementation**: This is also powered by Flask-SocketIO, delivering notifications to the author's specific user channel.
+*   **User Experience**: Authors are notified via a browser alert when viewing their post and a new comment arrives from someone else.
+
 ### Post Liking
 
 Users can now interact with blog posts by liking or unliking them, providing a simple way to show appreciation or engagement.

--- a/templates/base.html
+++ b/templates/base.html
@@ -65,5 +65,26 @@
     <footer>
         <p>&copy; 2023 My Flask App</p>
     </footer>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
+    <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', (event) => {
+            var socket = io.connect(location.protocol + '//' + document.domain + ':' + location.port);
+
+            socket.on('connect', function() {
+                console.log('SocketIO connected!');
+                {% if current_user and current_user.is_authenticated %}
+                var userRoom = 'user_{{ current_user.id }}';
+                socket.emit('join_room', {room: userRoom});
+                console.log('Joined room: ' + userRoom);
+                {% endif %}
+            });
+
+            // Optional: For debugging, listen to all events
+            // socket.onAny((event, ...args) => {
+            //   console.log(`Socket.IO event received: ${event}`, args);
+            // });
+        });
+    </script>
 </body>
 </html>

--- a/templates/view_post.html
+++ b/templates/view_post.html
@@ -223,11 +223,17 @@
 
 {% block scripts %}
 {{ super() }} {# Include scripts from base template if any #}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
+{# SocketIO client is now included in base.html and 'socket' variable should be globally available from there #}
 <script type="text/javascript">
   document.addEventListener('DOMContentLoaded', (event) => {
-    // Connect to SocketIO server
-    var socket = io();
+    // SocketIO connection is established in base.html.
+    // We assume 'socket' is a global variable initialized in base.html
+    if (typeof socket === 'undefined' || !socket) {
+        console.error('Socket.IO connection not found. Ensure base.html initializes it.');
+        // Fallback or error handling: try to connect if not already.
+        // This line might be removed if global 'socket' from base.html is reliable.
+        var socket = io.connect(location.protocol + '//' + document.domain + ':' + location.port);
+    }
 
     // Get post_id from the page
     var postId = {{ post.id if post else 'null' }}; // Ensure post.id is available
@@ -310,6 +316,21 @@
         if (noCommentsMessage) {
           noCommentsMessage.style.display = 'none'; // Hide or remove
         }
+      }
+    });
+
+    // Listen for the 'new_comment_notification' event for the post author
+    socket.on('new_comment_notification', function(data) {
+      // The user is already in their 'user_{user_id}' room (joined via base.html).
+      // This notification is targeted at them.
+      // We should check if the notification is for the post currently being viewed.
+      if (data.post_id === postId) {
+        // Display the notification. For now, using a simple alert.
+        let commentSnippet = data.comment_content;
+        if (commentSnippet.length > 50) {
+            commentSnippet = commentSnippet.substring(0, 47) + "...";
+        }
+        alert("User " + data.commenter_username + " commented on your post \"" + data.post_title + "\": " + commentSnippet);
       }
     });
   });


### PR DESCRIPTION
This commit introduces a real-time notification system for you when someone comments on your posts.

Key changes:

-   **Backend (`app.py`):**
    -   I modified the `add_comment` function to emit a `new_comment_notification`
        SocketIO event specifically to the post author's room (`user_{user_id}`).
    -   The event data includes `post_id`, `commenter_username`, `comment_content`,
        and `post_title`.
    -   I ensured authors do not receive notifications for their own comments.

-   **Frontend (`templates/base.html`, `templates/view_post.html`):**
    -   The SocketIO client library is now included in `base.html`.
    -   Logged-in users automatically join their user-specific SocketIO room
        (`user_{current_user.id}`) upon connecting.
    -   `view_post.html` now listens for the `new_comment_notification` event.
    -   If the notification pertains to the post being viewed by its author,
        a browser alert is displayed with the commenter's username, post title,
        and a snippet of the comment.

-   **Testing (`tests/test_app.py`):**
    -   I added `test_add_comment_socketio_notification_emission` to verify that
        the `new_comment_notification` event is correctly sent to the post author.
    -   I added `test_no_notification_for_own_comment` to ensure authors don't
        get notified for their own comments.

-   **Documentation (`README.md`):**
    -   I updated the "Blog Feature" section with a new sub-section
        "Author Comment Notifications" detailing this new functionality.

This feature enhances your engagement by providing immediate feedback to post authors about new comments on their content.