### PR TITLE
Add Content Recommendation API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,54 @@ Include the obtained `access_token` in the `Authorization` header as a Bearer to
         }
         ```
 
+### Content Recommendations API
+
+*   **GET /api/recommendations**
+    *   **Description:** Retrieves personalized content recommendations for a given user.
+    *   **Authentication:** Not required.
+    *   **Query Parameters:**
+        *   `user_id` (integer, required): The ID of the user for whom to fetch recommendations.
+    *   **Success Response (200 OK):**
+        *   **Content-Type:** `application/json`
+        *   **Body:** A JSON object containing the user's ID and various lists of suggested content.
+        *   **Example:**
+            ```json
+            {
+                "user_id": 1,
+                "suggested_posts": [
+                    {"id": 101, "title": "A Great Post", "author_username": "user2", "content": "...", "timestamp": "...", "user_id": 2, "hashtags": null, "is_featured": false, "featured_at": null}
+                ],
+                "suggested_groups": [
+                    {"id": 5, "name": "Cool Group", "description": "...", "creator_id": 3, "created_at": "...", "creator_username": "user3"}
+                ],
+                "suggested_events": [
+                    {"id": 12, "title": "Upcoming Event", "description": "...", "date": "...", "time": "...", "location": "...", "created_at": "...", "user_id": 2, "organizer_username": "user2"}
+                ],
+                "suggested_users_to_follow": [
+                    {"id": 4, "username": "user4", "email": "user4@example.com", "profile_picture": null, "bio": "...", "uploaded_images": null}
+                ],
+                "suggested_polls_to_vote": [
+                    {"id": 7, "question": "Favorite Color?", "user_id": 2, "created_at": "...", "author_username": "user2", "options": [{"id": 15, "text": "Blue", "vote_count": 0}, {"id": 16, "text": "Red", "vote_count": 0}]}
+                ]
+            }
+            ```
+    *   **Error Responses:**
+        *   **400 Bad Request:** If `user_id` is missing or invalid.
+            ```json
+            {
+                "message": {
+                    "user_id": "User ID is required and must be an integer."
+                }
+            }
+            ```
+            *(Note: The exact message for a missing parameter might be "Missing required parameter in the query string" or similar, depending on Flask-RESTful configuration.)*
+        *   **404 Not Found:** If the specified `user_id` does not exist.
+            ```json
+            {
+                "message": "User not found"
+            }
+            ```
+
 ### Posts API
 
 *   **GET /api/posts**

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ migrate = Migrate()
 # Import models after db and migrate are created, but before app context is needed for them usually
 # and definitely before db.init_app
 from models import User, Post, Comment, Like, Review, Message, Poll, PollOption, PollVote, Event, EventRSVP, Notification, TodoItem, Group, Reaction, Bookmark, Friendship, SharedPost, UserActivity, FlaggedContent, FriendPostNotification # Add UserActivity, FlaggedContent, GroupMessage, FriendPostNotification
-from api import UserListResource, UserResource, PostListResource, PostResource, EventListResource, EventResource
+from api import UserListResource, UserResource, PostListResource, PostResource, EventListResource, EventResource, RecommendationResource # Added RecommendationResource
 from recommendations import (
     suggest_users_to_follow, suggest_posts_to_read, suggest_groups_to_join,
     suggest_events_to_attend, suggest_polls_to_vote, suggest_hashtags,
@@ -43,6 +43,7 @@ api.add_resource(PostListResource, '/api/posts')
 api.add_resource(PostResource, '/api/posts/<int:post_id>')
 api.add_resource(EventListResource, '/api/events')
 api.add_resource(EventResource, '/api/events/<int:event_id>')
+api.add_resource(RecommendationResource, '/api/recommendations') # Added RecommendationResource endpoint
 
 # Scheduler for periodic tasks
 scheduler = BackgroundScheduler()

--- a/models.py
+++ b/models.py
@@ -28,6 +28,16 @@ class Group(db.Model):
     def __repr__(self):
         return f"<Group '{self.name}'>"
 
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'creator_id': self.creator_id,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'creator_username': self.creator.username if self.creator else None
+        }
+
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
@@ -216,6 +226,16 @@ class Poll(db.Model):
     def __repr__(self):
         return f'<Poll {self.question}>'
 
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'question': self.question,
+            'user_id': self.user_id,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'author_username': self.author.username if self.author else None,
+            'options': [option.to_dict() for option in self.options]
+        }
+
 class PollOption(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     text = db.Column(db.String(255), nullable=False)
@@ -225,6 +245,13 @@ class PollOption(db.Model):
 
     def __repr__(self):
         return f'<PollOption {self.text} for Poll {self.poll_id}>'
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'text': self.text,
+            'vote_count': len(self.votes)
+        }
 
 class PollVote(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,7 @@ import unittest
 import json # For checking JSON responses
 from unittest.mock import patch, call, ANY
 from app import app, db, socketio # Import socketio from app
-from models import User, Message, Post, Friendship, FriendPostNotification # Add other models as needed
+from models import User, Message, Post, Friendship, FriendPostNotification, Group, Event, Poll, PollOption # Added Group, Event, Poll, PollOption
 from datetime import datetime, timedelta
 from werkzeug.security import generate_password_hash
 
@@ -275,6 +275,149 @@ class TestFriendPostNotifications(AppTestCase): # Inherit from AppTestCase for s
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json, {'status': 'success', 'message': 'No unread friend post notifications.'})
             self.logout()
+
+
+class TestRecommendationAPI(AppTestCase):
+
+    def _create_db_group(self, creator_id, name="Test Group", description="A group for testing"):
+        group = Group(name=name, description=description, creator_id=creator_id)
+        db.session.add(group)
+        db.session.commit()
+        return group
+
+    def _create_db_event(self, user_id, title="Test Event", description="An event for testing", date="2024-12-31", time="18:00", location="Test Location"):
+        event = Event(title=title, description=description, date=date, time=time, location=location, user_id=user_id)
+        db.session.add(event)
+        db.session.commit()
+        return event
+
+    def _create_db_poll(self, user_id, question="Test Poll?", options_texts=None):
+        if options_texts is None:
+            options_texts = ["Option 1", "Option 2"]
+        poll = Poll(question=question, user_id=user_id)
+        db.session.add(poll)
+        db.session.flush() # So poll gets an ID before adding options
+        for text in options_texts:
+            option = PollOption(text=text, poll_id=poll.id)
+            db.session.add(option)
+        db.session.commit()
+        return poll
+
+    def setUp(self):
+        super().setUp() # Call parent setUp to get base users (self.user1, self.user2, self.user3)
+        # self.user1 is the target user for recommendations
+        # self.user2 will create content
+        # self.user3 is the "lonely" user
+
+        # Create some content by user2 that user1 might be recommended
+        self.post_by_user2 = self._create_db_post(user_id=self.user2_id, title="User2's Post")
+        self.group_by_user2 = self._create_db_group(creator_id=self.user2_id, name="User2's Group")
+        self.event_by_user2 = self._create_db_event(user_id=self.user2_id, title="User2's Event")
+        self.poll_by_user2 = self._create_db_poll(user_id=self.user2_id, question="User2's Poll?")
+
+        # User1 joins a different group (not by user2) to test suggest_groups_to_join logic (won't recommend this one)
+        # self.other_group_user1_member_of = self._create_db_group(creator_id=self.user3_id, name="Other Group")
+        # self.other_group_user1_member_of.members.append(self.user1)
+        # db.session.commit()
+
+
+    def test_get_recommendations_success(self):
+        with app.app_context():
+            response = self.client.get(f'/api/recommendations?user_id={self.user1_id}')
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.content_type, 'application/json')
+
+            data = json.loads(response.data)
+
+            self.assertIn('user_id', data)
+            self.assertEqual(data['user_id'], self.user1_id)
+
+            self.assertIn('suggested_posts', data)
+            self.assertIsInstance(data['suggested_posts'], list)
+            if data['suggested_posts']:
+                post = data['suggested_posts'][0]
+                self.assertIn('id', post)
+                self.assertIn('title', post)
+                self.assertIn('author_username', post)
+
+            self.assertIn('suggested_groups', data)
+            self.assertIsInstance(data['suggested_groups'], list)
+            if data['suggested_groups']:
+                group = data['suggested_groups'][0]
+                self.assertIn('id', group)
+                self.assertIn('name', group)
+                self.assertIn('creator_username', group)
+
+            self.assertIn('suggested_events', data)
+            self.assertIsInstance(data['suggested_events'], list)
+            if data['suggested_events']:
+                event = data['suggested_events'][0]
+                self.assertIn('id', event)
+                self.assertIn('title', event)
+                self.assertIn('organizer_username', event)
+
+            self.assertIn('suggested_users_to_follow', data)
+            self.assertIsInstance(data['suggested_users_to_follow'], list)
+            if data['suggested_users_to_follow']:
+                user = data['suggested_users_to_follow'][0]
+                self.assertIn('id', user)
+                self.assertIn('username', user)
+
+            self.assertIn('suggested_polls_to_vote', data)
+            self.assertIsInstance(data['suggested_polls_to_vote'], list)
+            if data['suggested_polls_to_vote']:
+                poll = data['suggested_polls_to_vote'][0]
+                self.assertIn('id', poll)
+                self.assertIn('question', poll)
+                self.assertIn('author_username', poll)
+                self.assertIn('options', poll)
+                self.assertIsInstance(poll['options'], list)
+                if poll['options']:
+                    option = poll['options'][0]
+                    self.assertIn('id', option)
+                    self.assertIn('text', option)
+                    self.assertIn('vote_count', option)
+
+    def test_get_recommendations_invalid_user_id(self):
+        with app.app_context():
+            response = self.client.get('/api/recommendations?user_id=99999')
+            self.assertEqual(response.status_code, 404)
+            data = json.loads(response.data)
+            self.assertIn('message', data)
+            # The message might be "User 99999 not found" or "User not found"
+            # Let's check if "not found" is in the message for robustness
+            self.assertTrue('not found' in data['message'].lower())
+
+
+    def test_get_recommendations_missing_user_id(self):
+        with app.app_context():
+            response = self.client.get('/api/recommendations')
+            self.assertEqual(response.status_code, 400)
+            data = json.loads(response.data)
+            self.assertIn('message', data)
+            # Example: {'message': {'user_id': 'User ID is required and must be an integer.'}}
+            # Exact message depends on reqparse error formatting
+            self.assertIn('user_id', data['message'])
+            self.assertTrue('required' in data['message']['user_id'].lower())
+
+
+    def test_get_recommendations_no_suggestions(self):
+        # self.user3 is set up by AppTestCase.setUp -> _setup_base_users()
+        # It has no specific content or interactions created in this class's setUp,
+        # so it should get minimal to no recommendations.
+        with app.app_context():
+            response = self.client.get(f'/api/recommendations?user_id={self.user3_id}')
+            self.assertEqual(response.status_code, 200)
+            data = json.loads(response.data)
+
+            self.assertEqual(data['user_id'], self.user3_id)
+            self.assertEqual(data['suggested_posts'], [])
+            self.assertEqual(data['suggested_groups'], [])
+            self.assertEqual(data['suggested_events'], [])
+            # user3 might be recommended user1 and user2 if the suggestion logic is simple
+            # For now, let's assert it's a list. More specific checks depend on recommendation logic.
+            self.assertIsInstance(data['suggested_users_to_follow'], list)
+            self.assertEqual(data['suggested_polls_to_vote'], [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit introduces a new API endpoint `/api/recommendations` that provides personalized content suggestions for you.

Key changes:
- Added `RecommendationResource` in `api.py` to handle GET requests to `/api/recommendations`. It takes a `user_id` query parameter and returns a JSON object with suggested posts, groups, events, users to follow, and polls.
- Registered the new resource in `app.py`.
- Added `to_dict()` methods to `Group`, `Poll`, and `PollOption` models in `models.py` for consistent serialization. Updated `RecommendationResource` to use these methods.
- Implemented comprehensive unit tests in `tests/test_app.py` for the new API endpoint, covering success scenarios, error handling (missing/invalid user_id, user not found), and cases with no recommendations.
- Updated `README.md` with detailed documentation for the `/api/recommendations` endpoint, including request parameters, response structure, and error codes.