### PR TITLE
feat: Implement Personalized Feed API Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,84 @@ Include the obtained `access_token` in the `Authorization` header as a Bearer to
             }
             ```
 
+*   **GET /api/personalized-feed**
+    *   **Description:** Provides a personalized feed of content (posts, events, polls) for the authenticated user, sorted by recency.
+    *   **Authentication:** Required. Expects a JWT Bearer token in the `Authorization` header.
+        *   Example: `Authorization: Bearer <your_jwt_access_token>`
+    *   **Success Response (200 OK):**
+        *   **Content-Type:** `application/json`
+        *   **Body:** A JSON array named `feed_items`. Each item in the array represents a piece of content and includes at least:
+            *   `type`: String - Identifies the type of content (e.g., "post", "event", "poll").
+            *   `timestamp`: String - ISO 8601 formatted timestamp. This is used to sort the feed, with the most recent items appearing first. For posts, this is the post's creation/update time. For events and polls, this is their creation time.
+            *   `id`: Integer - The unique ID of the content item.
+        *   **Post Item Structure (`type: "post"`)**:
+            *   `title`: String - The title of the post.
+            *   `content`: String - The main content of the post.
+            *   `author_username`: String - Username of the post's author.
+            *   `reason`: String - A brief explanation of why this post is recommended (e.g., "Liked by a friend", "Trending").
+            *   *(Other standard post fields may be present)*
+        *   **Event Item Structure (`type: "event"`)**:
+            *   `title`: String - The title of the event.
+            *   `description`: String - Description of the event.
+            *   `date`: String - The date of the event (e.g., "YYYY-MM-DD").
+            *   `time`: String - The time of the event (e.g., "HH:MM").
+            *   `location`: String - The location of the event.
+            *   `organizer_username`: String - Username of the event's organizer.
+            *   *(Other standard event fields may be present)*
+        *   **Poll Item Structure (`type: "poll"`)**:
+            *   `question`: String - The main question of the poll.
+            *   `creator_username`: String - Username of the poll's creator.
+            *   `options`: Array of objects - Each object represents a poll option and contains:
+                *   `id`: Integer - ID of the option.
+                *   `text`: String - Text of the option.
+                *   `vote_count`: Integer - Number of votes this option has received.
+            *   *(Other standard poll fields may be present)*
+        *   **Example `feed_items` Array:**
+            ```json
+            {
+                "feed_items": [
+                    {
+                        "type": "post",
+                        "id": 123,
+                        "timestamp": "2024-03-15T10:30:00Z",
+                        "title": "Exploring New APIs",
+                        "content": "A deep dive into new API development techniques...",
+                        "author_username": "jane_doe",
+                        "reason": "Liked by your friend John."
+                    },
+                    {
+                        "type": "event",
+                        "id": 78,
+                        "timestamp": "2024-03-14T15:00:00Z",
+                        "title": "Tech Meetup Vol. 5",
+                        "description": "Join us for the latest in tech.",
+                        "date": "2024-03-20",
+                        "time": "18:00",
+                        "location": "Community Hall",
+                        "organizer_username": "tech_guru"
+                    },
+                    {
+                        "type": "poll",
+                        "id": 45,
+                        "timestamp": "2024-03-13T09:00:00Z",
+                        "question": "What's your favorite programming language?",
+                        "creator_username": "code_master",
+                        "options": [
+                            {"id": 101, "text": "Python", "vote_count": 55},
+                            {"id": 102, "text": "JavaScript", "vote_count": 40}
+                        ]
+                    }
+                ]
+            }
+            ```
+    *   **Error Responses:**
+        *   **401 Unauthorized:** If the JWT token is missing, invalid, or expired.
+            ```json
+            {
+                "msg": "Missing Authorization Header" // Or other JWT-related error messages
+            }
+            ```
+
 ### Posts API
 
 *   **GET /api/posts**

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ migrate = Migrate()
 # Import models after db and migrate are created, but before app context is needed for them usually
 # and definitely before db.init_app
 from models import User, Post, Comment, Like, Review, Message, Poll, PollOption, PollVote, Event, EventRSVP, Notification, TodoItem, Group, Reaction, Bookmark, Friendship, SharedPost, UserActivity, FlaggedContent, FriendPostNotification # Add UserActivity, FlaggedContent, GroupMessage, FriendPostNotification
-from api import UserListResource, UserResource, PostListResource, PostResource, EventListResource, EventResource, RecommendationResource # Added RecommendationResource
+from api import UserListResource, UserResource, PostListResource, PostResource, EventListResource, EventResource, RecommendationResource, PersonalizedFeedResource # Added PersonalizedFeedResource
 from recommendations import (
     suggest_users_to_follow, suggest_posts_to_read, suggest_groups_to_join,
     suggest_events_to_attend, suggest_polls_to_vote, suggest_hashtags,
@@ -44,6 +44,7 @@ api.add_resource(PostResource, '/api/posts/<int:post_id>')
 api.add_resource(EventListResource, '/api/events')
 api.add_resource(EventResource, '/api/events/<int:event_id>')
 api.add_resource(RecommendationResource, '/api/recommendations') # Added RecommendationResource endpoint
+api.add_resource(PersonalizedFeedResource, '/api/personalized-feed')
 
 # Scheduler for periodic tasks
 scheduler = BackgroundScheduler()


### PR DESCRIPTION
This commit introduces a new API endpoint `/api/personalized-feed` that provides authenticated users with a personalized feed of content.

The feed includes recommended posts, events, and polls, aggregated and sorted by recency.

Key changes:
- Added `PersonalizedFeedResource` to `api.py` to handle feed generation logic.
- Leveraged existing recommendation functions in `recommendations.py`.
- Ensured items are serialized consistently with relevant details (e.g., author, reason for recommendation, poll options).
- Added comprehensive unit tests in `tests/test_app.py` for the new endpoint, covering authentication, successful responses, data structure, and empty feed scenarios.
- Updated `README.md` to document the new API endpoint, including request/response formats and authentication requirements.