### PR TITLE
feat: Implement user-to-user file sharing feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,38 @@ Enhancing the private communication capabilities, the application now supports r
 *   **Dedicated Activity Page**: A "Friend Activity" page (`/friend_post_notifications`) provides a chronological history of these notifications. Users can view details, link directly to the friend's post, and manage the read status of each notification (mark as read individually or mark all as read).
 *   **Technology**: Leverages Flask-SocketIO for real-time event emission and client-side JavaScript to display these toast notifications dynamically.
 
+### User-to-User File Sharing
+
+Allows users to securely share files directly with other registered users.
+
+*   **Functionality Details**:
+    *   **Sending Files**:
+        *   Users can initiate a file share from another user's profile page by clicking the "Share File with [username]" button, or by directly navigating to the share page if the recipient's username is known.
+        *   An optional message can be attached to the file share.
+        *   Supported file types include common documents, images, and archives (e.g., .txt, .pdf, .png, .jpg, .zip, .docx, .xlsx, .pptx).
+        *   There is a maximum file size limit (e.g., 16MB).
+    *   **Receiving Files**:
+        *   Users can view files shared with them in their "File Inbox", accessible from the main navigation bar.
+        *   Each file entry in the inbox displays the sender's username, the original filename, the upload timestamp, and any attached message.
+        *   New or unread files are visually highlighted in the inbox.
+    *   **Downloading Files**:
+        *   Files can be downloaded by clicking the "Download" link next to the file in the inbox.
+        *   Only the intended recipient and the original sender are authorized to download a shared file.
+        *   When a recipient downloads a file, it is automatically marked as "read".
+    *   **Deleting Files**:
+        *   Users can delete files from their inbox (if they are the receiver).
+        *   Users can also delete files they have sent (this action is also performed from their view of the file, typically the inbox if they sent it to themselves, or if a "sent files" view were implemented). The current implementation allows deletion if the user is either sender or receiver.
+
+*   **Routes & Key UI Points**:
+    *   `/files/share/<receiver_username>`: Page to initiate sharing a file with a specific user.
+    *   `/files/inbox`: Displays all files received by the logged-in user.
+    *   `/files/download/<shared_file_id>`: Endpoint for downloading a specific shared file (accessed via links in the inbox).
+    *   `/files/delete/<shared_file_id>`: Endpoint for deleting a shared file (accessed via buttons in the inbox).
+
+*   **Technical Notes**:
+    *   Files are stored in a dedicated secure folder on the server.
+    *   Unique filenames are used internally for stored files to prevent conflicts.
+
 ### Polls Feature
 
 This application now includes a "Polls" feature, allowing users to create and participate in polls.

--- a/models.py
+++ b/models.py
@@ -95,6 +95,10 @@ class User(db.Model):
     # Relationship to GroupMessage
     # group_messages = db.relationship('GroupMessage', backref='user', lazy='dynamic', cascade="all, delete-orphan")
 
+    # SharedFile relationships
+    sent_files = db.relationship('SharedFile', foreign_keys='SharedFile.sender_id', back_populates='sender', lazy='dynamic', cascade='all, delete-orphan')
+    received_files = db.relationship('SharedFile', foreign_keys='SharedFile.receiver_id', back_populates='receiver', lazy='dynamic', cascade='all, delete-orphan')
+
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     def __repr__(self):
@@ -474,3 +478,19 @@ class TrendingHashtag(db.Model):
             'rank': self.rank,
             'calculated_at': self.calculated_at.isoformat() if self.calculated_at else None,
         }
+
+class SharedFile(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    receiver_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    original_filename = db.Column(db.String(255), nullable=False)
+    saved_filename = db.Column(db.String(255), nullable=False, unique=True)
+    upload_timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    is_read = db.Column(db.Boolean, default=False, nullable=False)
+    message = db.Column(db.Text, nullable=True)
+
+    sender = db.relationship('User', foreign_keys=[sender_id], back_populates='sent_files')
+    receiver = db.relationship('User', foreign_keys=[receiver_id], back_populates='received_files')
+
+    def __repr__(self):
+        return f'<SharedFile {self.id} from {self.sender_id} to {self.receiver_id} - {self.original_filename}>'

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
                       <a class="nav-link" href="{{ url_for('view_friend_post_notifications') }}">Friend Activity</a>
                   </li>
                   <li><a href="{{ url_for('inbox') }}">Inbox</a></li>
+                  <li><a href="{{ url_for('files_inbox') }}">File Inbox</a></li>
                   <li><a href="{{ url_for('discover_feed') }}">Discovery</a></li> {# New Discovery Link #}
                   <li><a href="{{ url_for('trending_posts_page') }}">Trending</a></li>
                   {# Link to Friend Requests #}

--- a/templates/files_inbox.html
+++ b/templates/files_inbox.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block title %}My Shared Files Inbox{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>My Shared Files Inbox</h2>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }}">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    {% if not received_files %}
+        <p>You have not received any files.</p>
+    {% else %}
+        <div class="list-group">
+            {% for file in received_files %}
+                <div class="list-group-item {% if not file.is_read %}list-group-item-info{% endif %}">
+                    <div class="d-flex w-100 justify-content-between">
+                        <h5 class="mb-1">
+                            {{ file.original_filename }}
+                            {% if not file.is_read %}
+                                <span class="badge bg-primary">New</span>
+                            {% endif %}
+                        </h5>
+                        <small>{{ file.upload_timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+                    </div>
+                    <p class="mb-1">
+                        Sent by: <a href="{{ url_for('user_profile', username=file.sender.username) }}">{{ file.sender.username }}</a>
+                    </p>
+                    {% if file.message %}
+                        <p class="mb-1">Message: {{ file.message }}</p>
+                    {% endif %}
+                    <div class="mt-2">
+                        <a href="{{ url_for('download_shared_file', shared_file_id=file.id) }}" class="btn btn-sm btn-success">Download</a>
+                        <form action="{{ url_for('delete_shared_file', shared_file_id=file.id) }}" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this file?');">
+                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                        </form>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/share_file.html
+++ b/templates/share_file.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}Share File with {{ receiver_user.username }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Share File with {{ receiver_user.username }}</h2>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }}">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    <form method="POST" action="{{ url_for('share_file_route', receiver_username=receiver_user.username) }}" enctype="multipart/form-data">
+        <div class="mb-3">
+            <label for="file" class="form-label">Select file:</label>
+            <input type="file" name="file" id="file" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="message" class="form-label">Optional message:</label>
+            <textarea name="message" id="message" class="form-control" placeholder="Enter an optional message for {{ receiver_user.username }}"></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Send File</button>
+        <a href="{{ url_for('user_profile', username=receiver_user.username) }}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+{% endblock %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -68,9 +68,11 @@
         <a href="{{ url_for('user_activity_feed', username=user.username) }}" class="btn btn-outline-secondary btn-sm">View Activity Feed</a>
     </div>
 
-    {% if session['logged_in'] and session['username'] != username %}
-        <div class="mb-3">
-            <a href="{{ url_for('send_message', receiver_username=username) }}" class="btn btn-primary">Send Message to {{ username }}</a>
+    {# Actions for other users' profiles #}
+    {% if current_user and current_user.id != user.id %}
+        <div class="mb-3 text-center profile-actions-others">
+            <a href="{{ url_for('send_message', receiver_username=user.username) }}" class="btn btn-primary btn-sm">Send Message to {{ user.username }}</a>
+            <a href="{{ url_for('share_file_route', receiver_username=user.username) }}" class="btn btn-info btn-sm ms-2">Share File with {{ user.username }}</a>
         </div>
     {% endif %}
 


### PR DESCRIPTION
This commit introduces a new feature allowing users to share files directly with other registered users within the application.

Key functionalities include:
- Users can upload files and send them to specific recipients with an optional message.
- A dedicated "File Inbox" page (`/files/inbox`) lists all files received by you, highlighting unread files.
- Secure download of shared files, restricted to the sender and intended recipient. Downloading marks the file as read for the recipient.
- Ability for users to delete files they've sent or received.
- Configuration options for upload folder, allowed extensions, and max file size.

The implementation involved:
- Adding a `SharedFile` model to `models.py` and updating `User` relationships.
- Implementing backend logic in `app.py` for file handling (upload, download, delete), authorization, and database interactions.
- Creating new HTML templates (`share_file.html`, `files_inbox.html`) and updating `base.html` and `user.html` for UI integration.
- Adding a comprehensive suite of tests in `tests/test_app.py` to cover various scenarios, including success cases, error handling, and authorization.
- Documenting the new feature in `README.md`.