### PR TITLE
Fix: Correct comment API tests and JWT identity handling

### DIFF
--- a/api.py
+++ b/api.py
@@ -23,7 +23,7 @@ class UserResource(Resource):
 class PostListResource(Resource):
     @jwt_required()
     def post(self):
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         user = User.query.get(current_user_id)  # Use actual User model query
         if not user:
             return {"message": "User not found for provided token"}, 404
@@ -52,7 +52,7 @@ class PostListResource(Resource):
 class CommentListResource(Resource):
     @jwt_required()
     def post(self, post_id):
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         user = User.query.get(current_user_id)
         if not user:
             return {"message": "User not found"}, 404
@@ -106,7 +106,7 @@ class PollListResource(Resource):
 
     @jwt_required()
     def post(self):
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         user = User.query.get(current_user_id)
         if not user:
             return {"message": "User not found"}, 404
@@ -161,7 +161,7 @@ class PollResource(Resource):
 
     @jwt_required()
     def delete(self, poll_id):
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         poll = Poll.query.get(poll_id)
         if not poll:
             return {"message": "Poll not found"}, 404
@@ -179,7 +179,7 @@ class PollVoteResource(Resource):
     def post(
         self, poll_id
     ):  # The option_id was in the original plan, but typically it's in the request body.
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         user = User.query.get(
             current_user_id
         )  # Query user to ensure they exist, though jwt implies it.
@@ -221,7 +221,7 @@ class PollVoteResource(Resource):
 class PostLockResource(Resource):
     @jwt_required()
     def post(self, post_id):
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         user = User.query.get(current_user_id)
         if not user:
             return {"message": "User not found for provided token"}, 404
@@ -288,7 +288,7 @@ class PostLockResource(Resource):
 
     @jwt_required()
     def delete(self, post_id):
-        current_user_id = get_jwt_identity()
+        current_user_id = int(get_jwt_identity())
         user = User.query.get(current_user_id)
         if not user:
             return {"message": "User not found for provided token"}, 404

--- a/app.py
+++ b/app.py
@@ -2357,7 +2357,7 @@ def api_login():
     user = User.query.filter_by(username=username).first()
 
     if user and check_password_hash(user.password_hash, password):
-        access_token = create_access_token(identity=user.id)  # Use user.id as identity
+        access_token = create_access_token(identity=str(user.id))  # Use str(user.id) as identity
         return {"access_token": access_token}, 200
     else:
         return {"message": "Invalid credentials"}, 401

--- a/tests/test_comment_api.py
+++ b/tests/test_comment_api.py
@@ -4,7 +4,7 @@ import json
 # from unittest.mock import patch, ANY # Removed as not visibly used
 # from datetime import datetime, timedelta # Removed as not visibly used
 # from app import app, db, socketio # COMMENTED OUT
-# from models import User, Post, Comment # COMMENTED OUT
+from models import User, Post, Comment
 from tests.test_base import AppTestCase
 
 
@@ -13,9 +13,7 @@ class TestCommentAPI(AppTestCase):
     def test_create_comment_success(self):
         # with app.app_context(): # Handled by test client or AppTestCase helpers
         # user1 is created in AppTestCase's setUp
-        # test_post = self._create_db_post(user_id=self.user1_id, title="Post for Commenting")
-        # post_id = test_post.id
-        post_id = 1  # Mock post_id if db not live
+        post_id = self._create_db_post(user_id=self.user1_id, title="Post for Commenting")
 
         token = self._get_jwt_token(self.user1.username, "password")
         headers = {
@@ -25,13 +23,17 @@ class TestCommentAPI(AppTestCase):
         comment_content = "This is a test comment."
 
         # This response will depend on whether the post_id actually exists if db is live
-        # response = self.client.post(f'/api/posts/{post_id}/comments', headers=headers, json={'content': comment_content})
+        response = self.client.post(f'/api/posts/{post_id}/comments', headers=headers, json={'content': comment_content})
         # For now, assume the route might not deeply check post existence or is mocked
-        # self.assertEqual(response.status_code, 201, f"Response data: {response.data.decode()}")
-        # data = json.loads(response.data)
-        # self.assertEqual(data['message'], 'Comment created successfully')
-        # ... (rest of assertions)
-        pass  # Placeholder for DB dependent parts
+        self.assertEqual(response.status_code, 201, f"Response data: {response.data.decode()}")
+        data = json.loads(response.data)
+        self.assertEqual(data['message'], 'Comment created successfully')
+        self.assertIn('comment', data)
+        comment_data = data['comment']
+        self.assertEqual(comment_data['content'], comment_content)
+        self.assertEqual(comment_data['user_id'], self.user1_id)
+        self.assertEqual(comment_data['post_id'], post_id)
+        self.assertEqual(comment_data['author_username'], self.user1.username)
 
     def test_create_comment_unauthenticated(self):
         # with app.app_context():
@@ -62,14 +64,12 @@ class TestCommentAPI(AppTestCase):
             json={"content": "Commenting on nothing"},
         )
         self.assertEqual(response.status_code, 404)
-        # data = json.loads(response.data)
-        # self.assertEqual(data['message'], 'Post not found') # Message might vary
+        data = json.loads(response.data)
+        self.assertEqual(data['message'], 'Post not found')
 
     def test_create_comment_missing_content(self):
         # with app.app_context():
-        # test_post = self._create_db_post(user_id=self.user1_id, title="Post for Invalid Comment")
-        # post_id = test_post.id
-        post_id = 1  # Mock post_id
+        post_id = self._create_db_post(user_id=self.user1_id, title="Post for Invalid Comment")
 
         token = self._get_jwt_token(self.user1.username, "password")
         headers = {
@@ -80,7 +80,16 @@ class TestCommentAPI(AppTestCase):
             f"/api/posts/{post_id}/comments", headers=headers, json={}
         )
         self.assertEqual(response.status_code, 400)
-        # data = json.loads(response.data)
-        # self.assertIn('content', data['message'])
-        # self.assertIn('cannot be blank', data['message']['content'].lower())
-        pass  # Placeholder for specific error message check
+        data = json.loads(response.data)
+        self.assertIn('message', data)
+        # The actual message from api.py's reqparse is a dict when multiple errors,
+        # or string if a single error message is directly returned by help=
+        # For "Comment content cannot be blank", it's a direct help message.
+        # However, reqparse by default puts errors under a 'message' key, and if specific field error,
+        # it's often nested, e.g. data['message']['content']
+        # Checking api.py, CommentListResource uses:
+        # parser.add_argument("content", required=True, help="Comment content cannot be blank")
+        # This usually results in: {'message': {'content': 'Comment content cannot be blank'}}
+        # Let's adjust the assertion based on this.
+        self.assertIn('content', data['message'])
+        self.assertEqual(data['message']['content'], 'Comment content cannot be blank')


### PR DESCRIPTION
- I modified `tests/test_base.py` to register CommentListResource and PostListResource, making comment and post API endpoints available to the test client.
- I updated `tests/test_comment_api.py`:
    - I uncommented necessary model imports.
    - I fully implemented `test_create_comment_success` with post creation and detailed assertions for the comment data in the response.
    - I corrected assertions in `test_create_comment_post_not_found` to expect a 404 error with the message 'Post not found'.
    - I corrected assertions in `test_create_comment_missing_content` to expect a 400 error and verify the specific error message for missing content.
- I fixed JWT identity handling:
    - I modified `app.py` in `api_login` to cast `user.id` to `str` for `create_access_token`.
    - I modified `api.py` in resources using `get_jwt_identity` (PostListResource, CommentListResource, PollListResource, PollResource, PollVoteResource, PostLockResource) to cast the identity back to `int`. This resolves the "Subject must be a string" 422 error.

All tests in `test_comment_api.py` now pass, ensuring the comment API functionality is correctly tested.