### PR TITLE
Add tests for broadcast_new_post functionality

### DIFF
--- a/tests/test_realtime_post_notifications.py
+++ b/tests/test_realtime_post_notifications.py
@@ -1,10 +1,11 @@
 import unittest
 import json
-from unittest.mock import patch, ANY
+from unittest.mock import patch, ANY, MagicMock
 from datetime import datetime  # Removed timedelta
 
 # from app import app, db, socketio # COMMENTED OUT
 # from models import User, Post # COMMENTED OUT
+from app import broadcast_new_post, app as main_app_module
 from tests.test_base import AppTestCase
 
 
@@ -55,3 +56,108 @@ class TestRealtimePostNotifications(AppTestCase):
         self.assertIsInstance(broadcasted_data, dict)
         self.assertEqual(broadcasted_data["id"], created_post_id)
         self.assertEqual(broadcasted_data["title"], post_payload["title"])
+
+    @patch('app.new_post_sse_queues', new_callable=list) # Patch the list directly
+    @patch('flask.url_for') # Mock flask.url_for used by broadcast_new_post
+    def test_broadcast_new_post_with_url(self, mock_url_for, mock_new_post_sse_queues_list):
+        # Setup: Add a mock queue to our patched list
+        mock_queue = MagicMock()
+        mock_new_post_sse_queues_list.append(mock_queue)
+
+        # Define the expected URL that flask.url_for should return
+        expected_url = "http://localhost/post/123"
+        mock_url_for.return_value = expected_url
+
+        post_data = {'id': 123, 'title': 'Test Post with URL'}
+
+        # Call the function under test
+        # broadcast_new_post is imported from app
+        broadcast_new_post(post_data)
+
+        # Assertions
+        # 1. Check if flask.url_for was called correctly
+        mock_url_for.assert_called_once_with('view_post', post_id=123, _external=True)
+
+        # 2. Check if the mock queue's put method was called
+        mock_queue.put.assert_called_once()
+
+        # 3. Check the content of the data passed to queue.put()
+        # Get the actual data passed to put
+        args, _ = mock_queue.put.call_args
+        broadcasted_data = args[0]
+
+        self.assertEqual(broadcasted_data['id'], post_data['id'])
+        self.assertEqual(broadcasted_data['title'], post_data['title'])
+        self.assertIn('url', broadcasted_data)
+        self.assertEqual(broadcasted_data['url'], expected_url)
+
+    @patch('app.new_post_sse_queues', new_callable=list) # Patch the list
+    @patch('app.app.logger') # Mock app.logger
+    def test_broadcast_new_post_missing_id(self, mock_logger, mock_new_post_sse_queues_list):
+        # Setup: Add a mock queue to our patched list
+        mock_queue = MagicMock()
+        mock_new_post_sse_queues_list.append(mock_queue)
+
+        post_data = {'title': 'Test Post Missing ID'}
+
+        # Call the function under test
+        broadcast_new_post(post_data) # broadcast_new_post is imported from app
+
+        # Assertions
+        # 1. Check if app.logger.warning was called with the specific message
+        # The message in app.py is: "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
+        mock_logger.warning.assert_called_once_with(
+            "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
+        )
+
+        # 2. Check if the mock queue's put method was called
+        mock_queue.put.assert_called_once()
+
+        # 3. Check the content of the data passed to queue.put()
+        args, _ = mock_queue.put.call_args
+        broadcasted_data = args[0]
+
+        self.assertEqual(broadcasted_data['title'], post_data['title'])
+        self.assertNotIn('id', broadcasted_data) # id was not in original, should not be added
+        self.assertNotIn('url', broadcasted_data) # url should not be present
+
+    @patch('app.new_post_sse_queues', new_callable=list) # Patch the list
+    @patch('app.app.logger') # Mock app.logger
+    @patch('flask.url_for') # Mock flask.url_for
+    def test_broadcast_new_post_url_for_exception(self, mock_url_for, mock_logger, mock_new_post_sse_queues_list):
+        # Setup: Add a mock queue to our patched list
+        mock_queue = MagicMock()
+        mock_new_post_sse_queues_list.append(mock_queue)
+
+        # Configure flask.url_for mock to raise an exception
+        mock_url_for.side_effect = Exception("Test url_for error")
+
+        post_data = {'id': 456, 'title': 'Test Post URL Exception'}
+
+        # Call the function under test
+        broadcast_new_post(post_data) # broadcast_new_post is imported from app
+
+        # Assertions
+        # 1. Check if flask.url_for was called
+        mock_url_for.assert_called_once_with('view_post', post_id=456, _external=True)
+
+        # 2. Check if app.logger.error was called with the specific message
+        # The message in app.py is: f"Error generating URL for post ID {post_data_with_url.get('id')}: {e}. Sending notification without URL."
+        # We need to use ANY for the exception part of the message, or match the start of the message.
+        mock_logger.error.assert_called_once()
+        args, _ = mock_logger.error.call_args
+        log_message = args[0]
+        self.assertTrue(log_message.startswith(f"Error generating URL for post ID {post_data['id']}"))
+        self.assertIn("Sending notification without URL.", log_message)
+
+
+        # 3. Check if the mock queue's put method was called
+        mock_queue.put.assert_called_once()
+
+        # 4. Check the content of the data passed to queue.put()
+        args, _ = mock_queue.put.call_args
+        broadcasted_data = args[0]
+
+        self.assertEqual(broadcasted_data['id'], post_data['id'])
+        self.assertEqual(broadcasted_data['title'], post_data['title'])
+        self.assertNotIn('url', broadcasted_data) # url should not be present due to exception


### PR DESCRIPTION
This commit adds three new test cases to TestRealtimePostNotifications in tests/test_realtime_post_notifications.py. These tests directly verify the behavior of the `broadcast_new_post` function from `app.py`.

The new tests cover:
- Successful generation of a post URL and its inclusion in the broadcasted data.
- Correct handling when the post data is missing an 'id', ensuring a warning is logged and no URL is included.
- Correct handling when `flask.url_for` raises an exception during URL generation, ensuring an error is logged and no URL is included.

Mocking is used for `app.new_post_sse_queues`, `app.app.logger`, and `flask.url_for` to isolate the function and assert its interactions and output under these different conditions.