### PR TITLE
feat: Implement reordering of posts within a series

### DIFF
--- a/templates/edit_series.html
+++ b/templates/edit_series.html
@@ -26,19 +26,23 @@
     {# Posts currently in the series #}
     <h4>Posts in this Series</h4>
     {% if posts_in_series and posts_in_series|length > 0 %}
-        <ul class="list-group mb-3">
-            {% for post in posts_in_series %} {# series.posts is already ordered #}
-                <li class="list-group-item d-flex justify-content-between align-items-center">
+        <ul class="list-group mb-3" id="posts-in-series-list" data-series-id="{{ series.id }}">
+            {% for post in posts_in_series %} {# series.posts is already ordered by SeriesPost.order #}
+                <li class="list-group-item d-flex justify-content-between align-items-center" data-post-id="{{ post.id }}">
                     <span>
-                        #{{ loop.index }} <!-- Assuming series.posts is correctly ordered -->
                         <a href="{{ url_for('view_post', post_id=post.id) }}">{{ post.title }}</a>
                     </span>
-                    <form method="POST" action="{{ url_for('remove_post_from_series', series_id=series.id, post_id=post.id) }}" style="display: inline;">
-                        <button type="submit" class="btn btn-danger btn-sm">Remove</button>
-                    </form>
+                    <div>
+                        <button class="btn btn-secondary btn-sm me-1 move-up">Move Up</button>
+                        <button class="btn btn-secondary btn-sm me-1 move-down">Move Down</button>
+                        <form method="POST" action="{{ url_for('remove_post_from_series', series_id=series.id, post_id=post.id) }}" style="display: inline;">
+                            <button type="submit" class="btn btn-danger btn-sm">Remove</button>
+                        </form>
+                    </div>
                 </li>
             {% endfor %}
         </ul>
+        <button id="save-order-btn" class="btn btn-success mb-3">Save Order</button>
     {% else %}
         <p>No posts currently in this series.</p>
     {% endif %}
@@ -69,4 +73,91 @@
     </form>
 
 </div>
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const postsList = document.getElementById('posts-in-series-list');
+    if (!postsList) return;
+
+    const seriesId = postsList.dataset.seriesId;
+    const saveOrderBtn = document.getElementById('save-order-btn');
+
+    function updateButtonStates() {
+        const items = postsList.querySelectorAll('li');
+        items.forEach((item, index) => {
+            const moveUpBtn = item.querySelector('.move-up');
+            const moveDownBtn = item.querySelector('.move-down');
+
+            if (moveUpBtn) moveUpBtn.disabled = (index === 0);
+            if (moveDownBtn) moveDownBtn.disabled = (index === items.length - 1);
+        });
+        if (saveOrderBtn) { // Enable save button if there are items to save
+             saveOrderBtn.disabled = items.length === 0;
+        }
+    }
+
+    postsList.addEventListener('click', function (event) {
+        const target = event.target;
+        const currentItem = target.closest('li');
+        if (!currentItem) return;
+
+        if (target.classList.contains('move-up')) {
+            const previousItem = currentItem.previousElementSibling;
+            if (previousItem) {
+                postsList.insertBefore(currentItem, previousItem);
+                updateButtonStates();
+            }
+        } else if (target.classList.contains('move-down')) {
+            const nextItem = currentItem.nextElementSibling;
+            if (nextItem) {
+                postsList.insertBefore(nextItem, currentItem); // Insert next before current effectively moves current down
+                updateButtonStates();
+            }
+        }
+    });
+
+    if (saveOrderBtn) {
+        saveOrderBtn.addEventListener('click', function () {
+            const postIds = Array.from(postsList.querySelectorAll('li')).map(li => li.dataset.postId);
+
+            if (!seriesId) {
+                alert('Error: Series ID is missing.');
+                return;
+            }
+
+            fetch(`/series/${seriesId}/reorder_posts`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    // Include CSRF token if your app uses them for AJAX
+                    // 'X-CSRFToken': '{{ csrf_token() }}' // Example if using Flask-WTF
+                },
+                body: JSON.stringify({ post_ids: postIds })
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => { throw new Error(err.message || 'Failed to save order.') });
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data.status === 'success') {
+                    alert(data.message || 'Order saved successfully!');
+                    window.location.reload(); // Reload to see changes and ensure clean state
+                } else {
+                    alert(data.message || 'An unknown error occurred.');
+                }
+            })
+            .catch(error => {
+                console.error('Error saving order:', error);
+                alert('Error saving order: ' + error.message);
+            });
+        });
+    }
+
+    updateButtonStates(); // Initial setup
+});
+</script>
 {% endblock %}

--- a/tests/test_series_feature.py
+++ b/tests/test_series_feature.py
@@ -152,3 +152,80 @@ class TestSeriesFeature(AppTestCase):
         # response = self.client.get(f'/blog/post/{p2.id}?series_id={series.id}')
         # ... (assertions) ...
         pass
+
+    def test_reorder_posts_in_series(self):
+        import json
+        from models import db, Series, Post, SeriesPost # Ensure models are imported
+
+        # 1. Setup
+        self.login(self.user1.username, "password")
+
+        series = self._create_series(user_id=self.user1_id, title="Reorder Test Series")
+
+        # Create posts
+        post1_id = self._create_db_post(user_id=self.user1_id, title="Post Alpha")
+        post2_id = self._create_db_post(user_id=self.user1_id, title="Post Beta")
+        post3_id = self._create_db_post(user_id=self.user1_id, title="Post Gamma")
+
+        post1 = Post.query.get(post1_id)
+        post2 = Post.query.get(post2_id)
+        post3 = Post.query.get(post3_id)
+
+        self.assertIsNotNone(post1, "Post1 not found after creation")
+        self.assertIsNotNone(post2, "Post2 not found after creation")
+        self.assertIsNotNone(post3, "Post3 not found after creation")
+
+        # Add posts to series with initial order (0-indexed)
+        sp1 = SeriesPost(series_id=series.id, post_id=post1.id, order=0)
+        sp2 = SeriesPost(series_id=series.id, post_id=post2.id, order=1)
+        sp3 = SeriesPost(series_id=series.id, post_id=post3.id, order=2)
+        db.session.add_all([sp1, sp2, sp3])
+        db.session.commit()
+
+        # Verify initial order from series.posts property
+        db.session.refresh(series) # Refresh to load series_post_entries relationship
+        initial_ordered_posts = series.posts
+        self.assertEqual(len(initial_ordered_posts), 3)
+        self.assertEqual(initial_ordered_posts[0].id, post1.id)
+        self.assertEqual(initial_ordered_posts[1].id, post2.id)
+        self.assertEqual(initial_ordered_posts[2].id, post3.id)
+
+        # 2. Perform Reordering
+        new_order_ids = [post3.id, post1.id, post2.id]
+        response = self.client.post(
+            f'/series/{series.id}/reorder_posts',
+            data=json.dumps({'post_ids': new_order_ids}),
+            content_type='application/json'
+        )
+
+        # 3. Assert Initial Response
+        self.assertEqual(response.status_code, 200, f"Error: {response.json}")
+        self.assertIsNotNone(response.json, "Response is not JSON")
+        self.assertEqual(response.json.get('status'), 'success')
+
+        # 4. Assert Database State
+        db.session.refresh(series) # Refresh series to get updated relationships
+        # Or fetch again: updated_series = Series.query.get(series.id)
+
+        ordered_posts_after_reorder = series.posts # series.posts should be ordered by SeriesPost.order
+
+        self.assertEqual(len(ordered_posts_after_reorder), 3)
+        self.assertEqual(ordered_posts_after_reorder[0].id, post3.id, "Post 3 should be first")
+        self.assertEqual(ordered_posts_after_reorder[1].id, post1.id, "Post 1 should be second")
+        self.assertEqual(ordered_posts_after_reorder[2].id, post2.id, "Post 2 should be third")
+
+        # Directly check SeriesPost entries for 0-indexed order
+        sp_post1_updated = SeriesPost.query.filter_by(series_id=series.id, post_id=post1.id).first()
+        sp_post2_updated = SeriesPost.query.filter_by(series_id=series.id, post_id=post2.id).first()
+        sp_post3_updated = SeriesPost.query.filter_by(series_id=series.id, post_id=post3.id).first()
+
+        self.assertIsNotNone(sp_post1_updated)
+        self.assertIsNotNone(sp_post2_updated)
+        self.assertIsNotNone(sp_post3_updated)
+
+        self.assertEqual(sp_post3_updated.order, 0, "Post3 (new first) should have order 0")
+        self.assertEqual(sp_post1_updated.order, 1, "Post1 (new second) should have order 1")
+        self.assertEqual(sp_post2_updated.order, 2, "Post2 (new third) should have order 2")
+
+        # 5. Logout
+        self.logout()


### PR DESCRIPTION
This commit introduces functionality to reorder posts within a series.

Key changes include:

- Backend:
    - Added a new POST endpoint `/series/<series_id>/reorder_posts` to `app.py`.
    - This endpoint accepts a list of post IDs in the desired order.
    - It updates the `order` field in `SeriesPost` entries and the `updated_at` timestamp for the series.
    - Includes authorization to ensure only the series author can reorder.

- Frontend:
    - Modified `templates/edit_series.html` to include UI for reordering.
    - "Move Up" and "Move Down" buttons are added next to each post.
    - A "Save Order" button triggers JavaScript to send the new order to the backend via AJAX.

- Testing:
    - Added a new test case `test_reorder_posts_in_series` in `tests/test_series_feature.py`.
    - This test verifies the functionality of the reordering endpoint, ensuring correct API response and database updates.