### PR TITLE
feat: Implement user blocking for comments

### DIFF
--- a/api.py
+++ b/api.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import os
 
 import app as main_app  # Modified import
-from models import User, Post, Comment, Like, Friendship, Event, EventRSVP, Poll, PollOption, PollVote, db, PostLock, SharedFile
+from models import User, Post, Comment, Like, Friendship, Event, EventRSVP, Poll, PollOption, PollVote, db, PostLock, SharedFile, UserBlock
 
 
 # Placeholder for UserListResource
@@ -61,6 +61,15 @@ class CommentListResource(Resource):
         post = Post.query.get(post_id)
         if not post:
             return {"message": "Post not found"}, 404
+
+        # Placeholder for block check logic
+        # Conceptually, this will check if post.author has blocked user (current_user_id)
+        # For now, using 'if False:' to avoid breaking existing functionality.
+        # This will be replaced with actual logic once UserBlock model and relationships are implemented.
+        # Example: if post.author.has_blocked(user):
+        # Check if the post author has blocked the current user
+        if UserBlock.query.filter_by(blocker_id=post.user_id, blocked_id=user.id).first():
+            return {"message": "You are blocked by the post author and cannot comment."}, 403
 
         parser = reqparse.RequestParser()
         parser.add_argument(


### PR DESCRIPTION
This commit introduces functionality to prevent users from commenting on posts authored by users who have blocked them.

Key changes include:
- Added a new `UserBlock` model to `models.py` to store blocking relationships between users.
- Updated the `User` model with `blocked_users` and `blocked_by_users` relationships.
- Modified the `CommentListResource.post` method in `api.py` to check if the commenter is blocked by the post author. If blocked, the API returns a 403 Forbidden error.
- Added a new test case `test_create_comment_when_blocked_by_post_author` to `tests/test_comment_api.py` to verify this new functionality.
- Ensured that all checks pass after these changes.

The `UserBlock` model includes `blocker_id`, `blocked_id`, and a timestamp. It has unique constraints to prevent duplicate blocking entries and self-blocking. The API now queries this table before allowing a comment to be created. The new test case specifically creates users, a post, a blocking record, and then asserts that the blocked user receives a 403 error when attempting to comment.