### PR TITLE
feat: Add test for no friend post notifications when poster is blocked

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,6 +63,7 @@ from models import (
     Achievement,
     Series,
     SeriesPost,
+    UserBlock, # Added UserBlock
 )
 
 migrate = Migrate()
@@ -1089,6 +1090,14 @@ def create_post():
                         friend.id == post_author.id
                     ):  # Avoid notifying self if self is in friends list
                         continue
+
+                    # Check if the friend (potential recipient) has blocked the post_author
+                    is_blocked = UserBlock.query.filter_by(
+                        blocker_id=friend.id, blocked_id=post_author.id
+                    ).first()
+                    if is_blocked:
+                        app.logger.info(f"Skipping notification for friend {friend.id} (blocked by them) for post {new_post_db.id} by user {post_author.id}")
+                        continue  # Skip to the next friend
 
                     new_friend_notification = FriendPostNotification(
                         user_id=friend.id,


### PR DESCRIPTION
Adds a new test case to `test_friend_post_notifications.py` to ensure that you do not receive a friend post notification if you have blocked the user who created the post.

This change also includes a modification to the `create_post` route in `app.py` to check for a `UserBlock` record before creating and sending a `FriendPostNotification`. This fixes the bug identified by the new test case.

The `UserBlock` model is now correctly imported in `app.py`. All tests within `test_friend_post_notifications.py` pass after these changes.