### PR TITLE
Fix circular import errors

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -1,0 +1,52 @@
+# This file will store notification-related utilities to help break circular dependencies.
+# Initially, it will house new_post_sse_queues and broadcast_new_post.
+
+from flask import current_app, url_for
+import queue # broadcast_new_post uses queue.Queue for sse_listeners, and app.py uses it for new_post_sse_queues
+
+# Global list for SSE queues for new posts.
+# Each item in the list is a queue.Queue instance.
+new_post_sse_queues = []
+
+def broadcast_new_post(post_data):
+    """
+    Broadcasts new post data to all connected SSE clients.
+    This function is moved here to break a circular import between app.py and api.py.
+    """
+    # Ensure this function is called within an application context.
+    # The original function in app.py had extensive logging and error handling.
+    # It's important to replicate or adapt that as needed.
+
+    logger = current_app.logger # Get logger from current_app
+
+    post_data_with_url = post_data.copy()
+
+    if "id" in post_data_with_url:
+        try:
+            # url_for needs an app context, which should be present if called from a request or API endpoint.
+            post_data_with_url["url"] = url_for(
+                "view_post", post_id=post_data_with_url["id"], _external=True
+            )
+        except Exception as e:
+            logger.error(
+                f"Error generating URL for post ID {post_data_with_url.get('id')} in broadcast_new_post: {e}. Sending notification without URL."
+            )
+            if 'url' in post_data_with_url:
+                del post_data_with_url['url']
+    else:
+        logger.warning(
+            "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL."
+        )
+
+    if not new_post_sse_queues:
+        logger.warning("No SSE queues in new_post_sse_queues to send new post notifications to.")
+        return
+
+    logger.info(
+        f"Broadcasting new post from notifications.py: ID {post_data_with_url.get('id')}, Title: {post_data_with_url.get('title')} to {len(new_post_sse_queues)} clients. URL: {post_data_with_url.get('url', 'N/A')}"
+    )
+    for q_item in new_post_sse_queues:
+        try:
+            q_item.put(post_data_with_url)
+        except Exception as e:
+            logger.error(f"Error putting post_data_with_url into a queue in broadcast_new_post: {e}")

--- a/recommendations.py
+++ b/recommendations.py
@@ -1,4 +1,5 @@
-from app import db  # Added app for logger
+from flask import current_app
+# from app import db # Removed this line
 from models import (
     User,
     Post,
@@ -86,6 +87,7 @@ def suggest_users_to_follow(user_id, limit=5):
 
 def suggest_posts_to_read(user_id, limit=5):
     """Suggest posts liked or commented on by the current user's friends, ranked by recency of interaction."""
+    db = current_app.extensions['sqlalchemy']
     current_user = User.query.get(user_id)
     if not current_user:
         return []
@@ -216,6 +218,7 @@ def suggest_posts_to_read(user_id, limit=5):
 
     # Pre-fetch all likes and comments for efficiency if dealing with many posts
     # This avoids N+1 queries within the loop when accessing post.likes or post.comments
+    db = current_app.extensions['sqlalchemy']
     all_likes_query = db.session.query(Like.post_id, Like.user_id).all()
     post_likes_map = defaultdict(list)
     for post_id, liker_id in all_likes_query:
@@ -426,6 +429,7 @@ def suggest_groups_to_join(user_id, limit=5):
 
 
 def suggest_events_to_attend(user_id, limit=5):
+    db = current_app.extensions['sqlalchemy']
     current_user = User.query.get(user_id)
     if not current_user:
         return []
@@ -504,6 +508,7 @@ def suggest_events_to_attend(user_id, limit=5):
 
 
 def suggest_polls_to_vote(user_id, limit=5):
+    db = current_app.extensions['sqlalchemy']
     current_user = User.query.get(user_id)
     if not current_user:
         return []
@@ -650,6 +655,7 @@ def suggest_trending_posts(user_id, limit=5, since_days=7):
     Suggests trending posts based on recent activity (likes, comments) and post recency.
     Excludes posts by the user, or already interacted with/bookmarked by the user.
     """
+    db = current_app.extensions['sqlalchemy']
     current_user = User.query.get(user_id)
     if not current_user:
         return []
@@ -816,8 +822,9 @@ def suggest_trending_posts(user_id, limit=5, since_days=7):
 def update_trending_hashtags(top_n=10, since_days=7):
     """
     Calculates hashtag frequencies from recent posts, deletes existing trending
-    hashtags, and populates the TrendingHashtag table with the new top N hashtags.
+    hashtags, and populates TrendingHashtag table with the new top N hashtags.
     """
+    db = current_app.extensions['sqlalchemy']
     current_app.logger.info(
         f"Starting update_trending_hashtags job. Top N: {top_n}, Since Days: {since_days}"
     )


### PR DESCRIPTION
- Resolved circular import between app.py and api.py by moving notification-related functions and state to a new `notifications.py` module. `api.py` now uses `current_app` for Flask app context.
- Resolved circular import between api.py, recommendations.py, and app.py. `recommendations.py` now uses `current_app` to access database extensions and logger instead of importing directly from `app.py`.