### PR TITLE
Fix various test suite failures

### DIFF
--- a/static/profile_pics/05a324b7f9d442b38d683d718a8227cf_test_profile.png
+++ b/static/profile_pics/05a324b7f9d442b38d683d718a8227cf_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/static/profile_pics/273312236cbe425e8ae2a3cd7a5a8912_test_profile.png
+++ b/static/profile_pics/273312236cbe425e8ae2a3cd7a5a8912_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/static/profile_pics/a0a5b65c7bff42b5843a5793551d116f_test_profile.png
+++ b/static/profile_pics/a0a5b65c7bff42b5843a5793551d116f_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/static/profile_pics/b04116b0458b4001b7610278bd13470c_test_profile.png
+++ b/static/profile_pics/b04116b0458b4001b7610278bd13470c_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/tests/test_realtime_post_notifications.py
+++ b/tests/test_realtime_post_notifications.py
@@ -12,8 +12,8 @@ from tests.test_base import AppTestCase
 class TestRealtimePostNotifications(AppTestCase):
 
     @patch(
-        "app.broadcast_new_post"
-    )  # Patch the function where it's defined/imported, e.g., 'app.views.broadcast_new_post'
+        "api.broadcast_new_post"  # MODIFIED: Patch where it's called
+    )
     def test_create_post_api_triggers_broadcast(self, mock_broadcast_new_post_func):
         """
         Tests that creating a new post via the API correctly calls the
@@ -57,31 +57,32 @@ class TestRealtimePostNotifications(AppTestCase):
         self.assertEqual(broadcasted_data["id"], created_post_id)
         self.assertEqual(broadcasted_data["title"], post_payload["title"])
 
-    @patch('app.new_post_sse_queues', new_callable=list) # Patch the list directly
-    @patch('app.app.logger') # Mock app.logger
-    @patch('app.url_for') # Mock app.url_for (where it's used)
-    def test_broadcast_new_post_with_url(self, mock_url_for, mock_logger, mock_new_post_sse_queues_list):
+    @patch('notifications.new_post_sse_queues', new_callable=list)
+    @patch('notifications.url_for')
+    @patch('notifications.current_app', MagicMock(logger=MagicMock()))
+    # Test method signature expects args for url_for and new_post_sse_queues only
+    def test_broadcast_new_post_with_url(self, mock_url_for_obj, mock_new_post_sse_queues_list_obj): # MODIFIED SIGNATURE
+        # Access the logger from the pre-configured mock current_app
+        # Need to import notifications to access notifications.current_app
+        import notifications
+        mock_logger = notifications.current_app.logger
+
         # Setup: Add a mock queue to our patched list
         mock_queue = MagicMock()
-        mock_new_post_sse_queues_list.append(mock_queue)
+        mock_new_post_sse_queues_list_obj.append(mock_queue)
 
         # Define the expected URL that flask.url_for should return
         expected_url = "http://localhost/post/123"
-        mock_url_for.return_value = expected_url
+        mock_url_for_obj.return_value = expected_url
 
         post_data = {'id': 123, 'title': 'Test Post with URL'}
 
         # Call the function under test
-        # broadcast_new_post is imported from app
-        with self.app.app_context():
+        with main_app_module.app_context():
             broadcast_new_post(post_data)
 
         # Assertions
-        # 1. Check that the "missing id" warning was NOT called
-        # Construct the expected warning message carefully
-        missing_id_warning_msg = "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
-
-        # Check all calls to warning
+        missing_id_warning_msg = "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL."
         was_missing_id_warning_called = False
         for call_args in mock_logger.warning.call_args_list:
             if call_args[0][0] == missing_id_warning_msg:
@@ -89,18 +90,10 @@ class TestRealtimePostNotifications(AppTestCase):
                 break
         self.assertFalse(was_missing_id_warning_called, f"'{missing_id_warning_msg}' was unexpectedly logged.")
 
-        # 2. Check that logger.error was not called (i.e., url_for didn't silently fail)
         mock_logger.error.assert_not_called()
-
-        # 3. Check if flask.url_for was called correctly
-        mock_url_for.assert_called_once_with('view_post', post_id=123, _external=True)
-
-
-        # 4. Check if the mock queue's put method was called
+        mock_url_for_obj.assert_called_once_with('view_post', post_id=123, _external=True)
         mock_queue.put.assert_called_once()
 
-        # 3. Check the content of the data passed to queue.put()
-        # Get the actual data passed to put
         args, _ = mock_queue.put.call_args
         broadcasted_data = args[0]
 
@@ -109,26 +102,29 @@ class TestRealtimePostNotifications(AppTestCase):
         self.assertIn('url', broadcasted_data)
         self.assertEqual(broadcasted_data['url'], expected_url)
 
-    @patch('app.new_post_sse_queues', new_callable=list) # Patch the list
-    @patch('app.app.logger') # Mock app.logger
-    # Note: No @patch('flask.url_for') here, as it should not be called if 'id' is missing
-    def test_broadcast_new_post_missing_id(self, mock_logger, mock_new_post_sse_queues_list):
+    @patch('notifications.new_post_sse_queues', new_callable=list)
+    # Note: No @patch('notifications.url_for') here, as it should not be called if 'id' is missing
+    @patch('notifications.current_app', MagicMock(logger=MagicMock())) # MODIFIED
+    def test_broadcast_new_post_missing_id(self, mock_new_post_sse_queues_list_obj): # MODIFIED SIGNATURE
+        import notifications # Need this to access notifications.current_app.logger
+        mock_logger = notifications.current_app.logger
+
         # Setup: Add a mock queue to our patched list
         mock_queue = MagicMock()
-        mock_new_post_sse_queues_list.append(mock_queue)
+        mock_new_post_sse_queues_list_obj.append(mock_queue) # MODIFIED
 
         post_data = {'title': 'Test Post Missing ID'}
 
         # Call the function under test
-        with self.app.app_context(): # Added for consistency, though not strictly needed for this test's logic
+        with main_app_module.app_context(): # MODIFIED: Use main_app_module for app_context
             broadcast_new_post(post_data) # broadcast_new_post is imported from app
 
         # Assertions
         # 1. Check if app.logger.warning was called with the specific message
-        # The message in app.py is: "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
+        # The message in app.py is: "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL." # MODIFIED
         # This also implies flask.url_for should not have been called.
         mock_logger.warning.assert_any_call( # Use assert_any_call if other warnings might occur due to no queues.
-            "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
+            "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL." # MODIFIED
         )
         # Additionally, ensure the "no queues" warning is also there, as new_post_sse_queues is not empty here.
         # Actually, for this test, new_post_sse_queues has one mock queue.
@@ -138,7 +134,7 @@ class TestRealtimePostNotifications(AppTestCase):
         # And that 'no sse queues' is NOT called.
 
         # Check for the specific "missing id" warning.
-        missing_id_warning_msg = "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
+        missing_id_warning_msg = "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL." # MODIFIED
         no_queues_warning_msg = "No SSE queues to send new post notifications to."
 
         called_warnings = [c[0][0] for c in mock_logger.warning.call_args_list]
@@ -157,125 +153,125 @@ class TestRealtimePostNotifications(AppTestCase):
         self.assertNotIn('id', broadcasted_data) # id was not in original, should not be added
         self.assertNotIn('url', broadcasted_data) # url should not be present
 
-    @patch('app.new_post_sse_queues', new_callable=list) # Patch the list
-    @patch('app.app.logger') # Mock app.logger
-    @patch('app.url_for') # Mock app.url_for (where it's used)
-    def test_broadcast_new_post_url_for_exception(self, mock_url_for, mock_logger, mock_new_post_sse_queues_list):
+    @patch('notifications.new_post_sse_queues', new_callable=list)
+    @patch('notifications.url_for')
+    @patch('notifications.current_app', MagicMock(logger=MagicMock()))
+    def test_broadcast_new_post_url_for_exception(self, mock_url_for_obj, mock_new_post_sse_queues_list_obj): # MODIFIED SIGNATURE
+        import notifications
+        mock_logger = notifications.current_app.logger
+
         # Setup: Add a mock queue to our patched list
         mock_queue = MagicMock()
-        mock_new_post_sse_queues_list.append(mock_queue)
+        mock_new_post_sse_queues_list_obj.append(mock_queue) # MODIFIED
 
         # Configure flask.url_for mock to raise an exception
-        mock_url_for.side_effect = Exception("Test url_for error")
+        mock_url_for_obj.side_effect = Exception("Test url_for error") # MODIFIED
 
         post_data = {'id': 456, 'title': 'Test Post URL Exception'}
 
         # Call the function under test
-        with self.app.app_context():
-            broadcast_new_post(post_data) # broadcast_new_post is imported from app
+        with main_app_module.app_context():
+            broadcast_new_post(post_data)
 
         # Assertions
-        # 1. Check if flask.url_for was called
-        mock_url_for.assert_called_once_with('view_post', post_id=456, _external=True)
+        mock_url_for_obj.assert_called_once_with('view_post', post_id=456, _external=True) # MODIFIED
 
-
-        # 2. Check if app.logger.error was called with the specific message
-        # The message in app.py is: f"Error generating URL for post ID {post_data_with_url.get('id')}: {e}. Sending notification without URL."
-        # We need to use ANY for the exception part of the message, or match the start of the message.
         mock_logger.error.assert_called_once()
         args, _ = mock_logger.error.call_args
         log_message = args[0]
         self.assertTrue(log_message.startswith(f"Error generating URL for post ID {post_data['id']}"))
         self.assertIn("Sending notification without URL.", log_message)
 
-
-        # 3. Check if the mock queue's put method was called
         mock_queue.put.assert_called_once()
 
-        # 4. Check the content of the data passed to queue.put()
         args, _ = mock_queue.put.call_args
         broadcasted_data = args[0]
 
         self.assertEqual(broadcasted_data['id'], post_data['id'])
         self.assertEqual(broadcasted_data['title'], post_data['title'])
-        self.assertNotIn('url', broadcasted_data) # url should not be present due to exception
+        self.assertNotIn('url', broadcasted_data)
 
-    @patch('app.app.logger') # To mock app.logger
-    @patch('app.url_for')   # To mock app.url_for (where it's used)
-    def test_broadcast_new_post_with_no_queues(self, mock_url_for, mock_logger):
-        import app as app_module # Import the module where new_post_sse_queues is defined
+    @patch('notifications.url_for') # This will be mock_url_for_obj
+    @patch('notifications.current_app', MagicMock(logger=MagicMock())) # No arg for this
+    def test_broadcast_new_post_with_no_queues(self, mock_url_for_obj): # MODIFIED SIGNATURE
+        import notifications # For logger and new_post_sse_queues
+        mock_logger = notifications.current_app.logger
 
-        original_queues = list(app_module.new_post_sse_queues) # Make a copy of the original list
-        app_module.new_post_sse_queues.clear() # Directly modify the list in the module to be empty
+        original_queues = list(notifications.new_post_sse_queues) # MODIFIED: Use notifications directly
+        notifications.new_post_sse_queues.clear() # MODIFIED: Use notifications directly
 
         try:
             # Confirm the list is empty before the call
-            self.assertEqual(len(app_module.new_post_sse_queues), 0)
+            self.assertEqual(len(notifications.new_post_sse_queues), 0) # MODIFIED
 
-            with self.app.app_context(): # Ensure Flask app context for logger (and url_for if it were called)
+            with main_app_module.app_context(): # MODIFIED: Use main_app_module for app_context
                 broadcast_new_post({'title': 'Test No Queues'}) # 'id' is missing
 
             # Check for both warnings
-            expected_warning_id_missing = "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
-            expected_warning_no_queues = "No SSE queues to send new post notifications to."
+            expected_warning_id_missing = "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL."
+            expected_warning_no_queues = "No SSE queues in new_post_sse_queues to send new post notifications to." # MODIFIED
 
             called_warnings = [c[0][0] for c in mock_logger.warning.call_args_list]
             self.assertIn(expected_warning_id_missing, called_warnings)
             self.assertIn(expected_warning_no_queues, called_warnings)
             self.assertEqual(len(called_warnings), 2) # Ensure exactly these two warnings
 
-            mock_url_for.assert_not_called()
+            mock_url_for_obj.assert_not_called()
         finally:
             # Restore original list
-            app_module.new_post_sse_queues.clear()
-            app_module.new_post_sse_queues.extend(original_queues)
+            notifications.new_post_sse_queues.clear()
+            notifications.new_post_sse_queues.extend(original_queues) # MODIFIED
 
-    @patch('app.app.logger')
-    @patch('app.new_post_sse_queues', new_callable=list)
-    @patch('app.url_for') # Mock app.url_for (where it's used)
-    def test_broadcast_new_post_empty_data_no_queues(self, mock_url_for, mock_new_post_sse_queues_list, mock_logger):
+    @patch('notifications.new_post_sse_queues', new_callable=list)
+    @patch('notifications.url_for')
+    @patch('notifications.current_app', MagicMock(logger=MagicMock()))
+    def test_broadcast_new_post_empty_data_no_queues(self, mock_url_for_obj, mock_new_post_sse_queues_list_obj): # MODIFIED SIGNATURE
+        import notifications
+        mock_logger = notifications.current_app.logger
         """
         Tests broadcast_new_post with empty data and no SSE queues.
         Checks for appropriate logging and no flask.url_for call.
         """
         # Ensure new_post_sse_queues is empty (handled by new_callable=list)
-        self.assertEqual(len(mock_new_post_sse_queues_list), 0)
+        self.assertEqual(len(mock_new_post_sse_queues_list_obj), 0) # MODIFIED
 
-        with self.app.app_context():
+        with main_app_module.app_context():
             broadcast_new_post({})
 
         # Assert that flask.url_for was not called
-        mock_url_for.assert_not_called()
+        mock_url_for_obj.assert_not_called() # MODIFIED
 
         # Assert logger warnings
-        expected_warning_id_missing = "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
-        expected_warning_no_queues = "No SSE queues to send new post notifications to."
+        expected_warning_id_missing = "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL."
+        expected_warning_no_queues = "No SSE queues in new_post_sse_queues to send new post notifications to." # MODIFIED
 
         # Check all calls to warning
         called_warnings = [c[0][0] for c in mock_logger.warning.call_args_list]
         self.assertIn(expected_warning_id_missing, called_warnings)
         self.assertIn(expected_warning_no_queues, called_warnings)
 
-    @patch('app.app.logger')
-    @patch('app.new_post_sse_queues', new_callable=list)
-    @patch('app.url_for') # Mock app.url_for (where it's used)
-    def test_broadcast_new_post_empty_data_with_queue(self, mock_url_for, mock_new_post_sse_queues_list, mock_logger):
+    @patch('notifications.new_post_sse_queues', new_callable=list)
+    @patch('notifications.url_for')
+    @patch('notifications.current_app', MagicMock(logger=MagicMock()))
+    def test_broadcast_new_post_empty_data_with_queue(self, mock_url_for_obj, mock_new_post_sse_queues_list_obj): # MODIFIED SIGNATURE
+        import notifications
+        mock_logger = notifications.current_app.logger
         """
         Tests broadcast_new_post with empty data but with an SSE queue.
         Checks for appropriate logging, no flask.url_for call, and queue interaction.
         """
         # Add a mock queue
         mock_queue = MagicMock()
-        mock_new_post_sse_queues_list.append(mock_queue)
+        mock_new_post_sse_queues_list_obj.append(mock_queue) # MODIFIED
 
-        with self.app.app_context():
+        with main_app_module.app_context():
             broadcast_new_post({})
 
         # Assert that flask.url_for was not called
-        mock_url_for.assert_not_called()
+        mock_url_for_obj.assert_not_called() # MODIFIED
 
         # Assert logger warnings
-        expected_warning_id_missing = "Post data missing 'id' field, cannot generate URL for SSE notification. Sending notification without URL."
+        expected_warning_id_missing = "Post data missing 'id' field in broadcast_new_post, cannot generate URL for SSE notification. Sending notification without URL."
         warning_no_queues = "No SSE queues to send new post notifications to."
 
         called_warnings = [c[0][0] for c in mock_logger.warning.call_args_list]
@@ -288,6 +284,6 @@ class TestRealtimePostNotifications(AppTestCase):
         # Assert the data put to the queue
         args, _ = mock_queue.put.call_args
         broadcasted_data = args[0]
-        self.assertEqual(broadcasted_data, {}) # Should be an empty dict
+        self.assertEqual(broadcasted_data, {})
         self.assertNotIn('id', broadcasted_data)
         self.assertNotIn('url', broadcasted_data)


### PR DESCRIPTION
- Install missing dependencies from requirements.txt.
- Correct mock patch targets and logger mocking strategy in test_realtime_post_notifications.py.
- Update expected warning messages in test_realtime_post_notifications.py.
- Correct authorization logic in test_user_feed_api.py to ensure the mocked function's call conditions are met.

Note: One test `test_get_feed_empty_for_new_user_no_relevant_content` in `test_user_feed_api.py` still fails. This may indicate an issue in the API endpoint's logic (e.g., an unexpected early return) rather than the test setup.