### PR TITLE
Fix: Replace legacy Query.get with Session.get

### DIFF
--- a/achievements_logic.py
+++ b/achievements_logic.py
@@ -58,7 +58,7 @@ def check_and_award_achievements(user_id):
     Checks all defined achievements for a given user and awards them if criteria are met
     and the user hasn't already received them.
     """
-    user = User.query.get(user_id)
+    user = db.session.get(User, user_id)
     if not user:
         return {"error": "User not found"}, 404
 

--- a/api.py
+++ b/api.py
@@ -26,7 +26,7 @@ class PostListResource(Resource):
     @jwt_required()
     def post(self):
         current_user_id = int(get_jwt_identity())
-        user = User.query.get(current_user_id)  # Use actual User model query
+        user = db.session.get(User, current_user_id)  # Use actual User model query
         if not user:
             return {"message": "User not found for provided token"}, 404
 
@@ -55,11 +55,11 @@ class CommentListResource(Resource):
     @jwt_required()
     def post(self, post_id):
         current_user_id = int(get_jwt_identity())
-        user = User.query.get(current_user_id)
+        user = db.session.get(User, current_user_id)
         if not user:
             return {"message": "User not found"}, 404
 
-        post = Post.query.get(post_id)
+        post = db.session.get(Post, post_id)
         if not post:
             return {"message": "Post not found"}, 404
 
@@ -118,7 +118,7 @@ class PollListResource(Resource):
     @jwt_required()
     def post(self):
         current_user_id = int(get_jwt_identity())
-        user = User.query.get(current_user_id)
+        user = db.session.get(User, current_user_id)
         if not user:
             return {"message": "User not found"}, 404
 
@@ -165,7 +165,7 @@ class PollListResource(Resource):
 class PollResource(Resource):
     @jwt_required()
     def get(self, poll_id):
-        poll = Poll.query.get(poll_id)
+        poll = db.session.get(Poll, poll_id)
         if not poll:
             return {"message": "Poll not found"}, 404
         return {"poll": poll.to_dict()}, 200
@@ -173,7 +173,7 @@ class PollResource(Resource):
     @jwt_required()
     def delete(self, poll_id):
         current_user_id = int(get_jwt_identity())
-        poll = Poll.query.get(poll_id)
+        poll = db.session.get(Poll, poll_id)
         if not poll:
             return {"message": "Poll not found"}, 404
 
@@ -191,13 +191,13 @@ class PollVoteResource(Resource):
         self, poll_id
     ):  # The option_id was in the original plan, but typically it's in the request body.
         current_user_id = int(get_jwt_identity())
-        user = User.query.get(
+        user = db.session.get(User,
             current_user_id
         )  # Query user to ensure they exist, though jwt implies it.
         if not user:
             return {"message": "User not found"}, 404
 
-        poll = Poll.query.get(poll_id)
+        poll = db.session.get(Poll, poll_id)
         if not poll:
             return {"message": "Poll not found"}, 404
 
@@ -233,11 +233,11 @@ class PostLockResource(Resource):
     @jwt_required()
     def post(self, post_id):
         current_user_id = int(get_jwt_identity())
-        user = User.query.get(current_user_id)
+        user = db.session.get(User, current_user_id)
         if not user:
             return {"message": "User not found for provided token"}, 404
 
-        post = Post.query.get(post_id)
+        post = db.session.get(Post, post_id)
         if not post:
             return {"message": "Post not found"}, 404
 
@@ -298,11 +298,11 @@ class PostLockResource(Resource):
     @jwt_required()
     def delete(self, post_id):
         current_user_id = int(get_jwt_identity())
-        user = User.query.get(current_user_id)
+        user = db.session.get(User, current_user_id)
         if not user:
             return {"message": "User not found for provided token"}, 404
 
-        post = Post.query.get(post_id)
+        post = db.session.get(Post, post_id)
         if not post:
             return {"message": "Post not found"}, 404
 
@@ -372,7 +372,7 @@ class RecommendationResource(Resource):
         args = parser.parse_args()
         user_id = args["user_id"]
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             return {"message": f"User {user_id} not found"}, 404
 
@@ -461,7 +461,7 @@ class UserFeedResource(Resource):
     def get(self, user_id):
         # current_user_id = int(get_jwt_identity()) # Not strictly needed unless for auth checks
 
-        target_user = User.query.get(user_id)
+        target_user = db.session.get(User, user_id)
         if not target_user:
             return {"message": "User not found"}, 404
 
@@ -488,7 +488,7 @@ class PersonalizedFeedResource(Resource):
     @jwt_required()
     def get(self):
         current_user_id = int(get_jwt_identity())
-        current_user = User.query.get(current_user_id)
+        current_user = db.session.get(User, current_user_id)
 
         if not current_user:
             return {"message": "User not found"}, 404
@@ -637,7 +637,7 @@ class OnThisDayResource(Resource):
             return {"message": "Invalid user identity in token"}, 400
 
         # It's good practice to ensure the user exists, though jwt_required handles token validity.
-        user = User.query.get(current_user_id)
+        user = db.session.get(User, current_user_id)
         if not user:
             return {"message": "User not found for provided token"}, 404
 
@@ -667,11 +667,11 @@ class UserStatsResource(Resource):
 
         if current_jwt_user_id != user_id:
             # Future: Add admin role check here to allow admins access
-            # requesting_user = User.query.get(current_jwt_user_id)
+            # requesting_user = db.session.get(User, current_jwt_user_id)
             # if not (requesting_user and requesting_user.role == 'admin'):
             return {"message": "You are not authorized to view these stats."}, 403
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             return {"message": "User not found"}, 404
 
@@ -707,7 +707,7 @@ class SharedFileResource(Resource):
             current_app.logger.error(f"Invalid user identity format in JWT: {current_user_id_str}")
             return {"message": "Invalid user identity format."}, 400
 
-        shared_file = SharedFile.query.get(file_id)
+        shared_file = db.session.get(SharedFile, file_id)
 
         if not shared_file:
             return {"message": "File not found"}, 404

--- a/static/profile_pics/10b6a1baf6ab48deaa3bc096af9a6ef6_test_profile.png
+++ b/static/profile_pics/10b6a1baf6ab48deaa3bc096af9a6ef6_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/static/profile_pics/131da5b9267d4725826d1a64a469a0ae_test_profile.png
+++ b/static/profile_pics/131da5b9267d4725826d1a64a469a0ae_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/static/profile_pics/473195fec1db491eb866901d4efa00d4_test_profile.png
+++ b/static/profile_pics/473195fec1db491eb866901d4efa00d4_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/static/profile_pics/88cffb63bb3d48e1bb7209d327d06b13_test_profile.png
+++ b/static/profile_pics/88cffb63bb3d48e1bb7209d327d06b13_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -246,7 +246,7 @@ class AppTestCase(unittest.TestCase):
             self.db.session.commit() # Use class's db
 
             # Debug check
-            retrieved_post = Post.query.get(post.id)
+            retrieved_post = self.db.session.get(Post, post.id)
             if retrieved_post is None:
                 print(f"DEBUG: Post with id {post.id} was NOT found immediately after commit in _create_db_post!")
                 # Optionally raise an exception to make it a hard failure here

--- a/tests/test_comment_api.py
+++ b/tests/test_comment_api.py
@@ -36,7 +36,7 @@ class TestCommentAPI(AppTestCase):
             self.assertEqual(comment_data['author_username'], self.user1.username)
 
             # Verify the comment is in the database
-            comment_in_db = Comment.query.get(data["comment"]["id"])
+            comment_in_db = self.db.session.get(Comment, data["comment"]["id"])
             self.assertIsNotNone(comment_in_db)
             self.assertEqual(comment_in_db.content, comment_content) # Use variable with period
             self.assertEqual(comment_in_db.user_id, self.user1.id)

--- a/tests/test_file_sharing.py
+++ b/tests/test_file_sharing.py
@@ -517,7 +517,7 @@ class TestFileSharing(AppTestCase):
             # self.assertEqual(response_json['message'], "File deleted successfully") # Already checked
 
             self.assertFalse(os.path.exists(file_path), "Physical file should be deleted from filesystem.")
-            self.assertIsNone(SharedFile.query.get(file_id_to_delete), "DB record should be deleted.")
+            self.assertIsNone(self.db.session.get(SharedFile, file_id_to_delete), "DB record should be deleted.")
 
         self.logout()
 
@@ -568,7 +568,7 @@ class TestFileSharing(AppTestCase):
         with self.app.app_context():
             # Step 4: Assertions (continued) - DB and filesystem checks
             self.assertFalse(os.path.exists(file_path), "Physical file should be deleted by sender.") # file_path from above context
-            self.assertIsNone(SharedFile.query.get(file_id_to_delete), "DB record should be deleted by sender.")
+            self.assertIsNone(self.db.session.get(SharedFile, file_id_to_delete), "DB record should be deleted by sender.")
 
         self.logout()
 
@@ -618,7 +618,7 @@ class TestFileSharing(AppTestCase):
         with self.app.app_context():
             # Assertions on file system and DB state
             self.assertTrue(os.path.exists(file_path), "Physical file should NOT be deleted by unauthorized user.")
-            self.assertIsNotNone(SharedFile.query.get(file_id_to_attempt_delete), "DB record should NOT be deleted by unauthorized user.")
+            self.assertIsNotNone(self.db.session.get(SharedFile, file_id_to_attempt_delete), "DB record should NOT be deleted by unauthorized user.")
             # Clean up the physical file that was not deleted by the test logic
             if os.path.exists(file_path):
                 os.remove(file_path)

--- a/tests/test_like_notifications.py
+++ b/tests/test_like_notifications.py
@@ -23,7 +23,7 @@ class TestLikeNotifications(AppTestCase):
             db.session.add(self.author2)
             db.session.commit()
             # Fetch from DB to ensure it's a managed object, consistent with others
-            self.author2 = User.query.get(self.author2.id)
+            self.author2 = self.db.session.get(User, self.author2.id)
 
     @patch(
         "app.socketio.emit"

--- a/tests/test_live_activity_feed.py
+++ b/tests/test_live_activity_feed.py
@@ -128,7 +128,7 @@ class TestLiveActivityFeed(AppTestCase):
             }
 
             # Re-fetch user2 to ensure friend relationships are up-to-date after accepting request
-            user2_updated = User.query.get(self.user2.id)
+            user2_updated = self.db.session.get(User, self.user2.id)
             friends_of_user2 = user2_updated.get_friends()
 
             emit_calls = []
@@ -351,7 +351,7 @@ class TestLiveActivityFeed(AppTestCase):
             activity = UserActivity.query.filter_by(user_id=self.user2.id, activity_type='new_post').order_by(UserActivity.timestamp.desc()).first()
             self.assertIsNotNone(activity, "UserActivity for 'new_post' was not created.")
 
-            created_post = Post.query.get(activity.related_id)
+            created_post = self.db.session.get(Post, activity.related_id)
             self.assertIsNotNone(created_post, "Post referred in activity not found.")
             self.assertEqual(created_post.title, post_title)
             self.assertEqual(activity.user_id, self.user2.id)
@@ -684,7 +684,7 @@ class TestLiveActivityFeed(AppTestCase):
 
         # Store current profile picture to check it changes
         with self.app.app_context():
-            user1_before_update = User.query.get(self.user1.id)
+            user1_before_update = self.db.session.get(User, self.user1.id)
             original_profile_pic = user1_before_update.profile_picture
 
         # 2. Prepare a mock image file
@@ -705,7 +705,7 @@ class TestLiveActivityFeed(AppTestCase):
 
         # Verify that user1's profile picture path has changed in DB
         with self.app.app_context():
-            user1_after_update = User.query.get(self.user1.id)
+            user1_after_update = self.db.session.get(User, self.user1.id)
             self.assertIsNotNone(user1_after_update.profile_picture, "User profile picture path should be set in the database.")
             self.assertNotEqual(original_profile_pic, user1_after_update.profile_picture, "User profile picture path should have changed from the original.")
             self.assertTrue(user1_after_update.profile_picture.startswith('/static/profile_pics/'), "Profile picture path should start with /static/profile_pics/.")
@@ -729,7 +729,7 @@ class TestLiveActivityFeed(AppTestCase):
             # 5. Verify socketio.emit call
             # self.user1 is friends with self.user2 (established in TestLiveActivityFeed.setUp via AppTestCase helper)
             # The profile_picture in the payload is the new one, taken from user1_after_update.profile_picture
-            user1_after_update = User.query.get(self.user1.id) # Re-fetch to ensure we have the latest state for payload
+            user1_after_update = self.db.session.get(User, self.user1.id) # Re-fetch to ensure we have the latest state for payload
 
             expected_payload = {
                 "activity_id": activity.id,

--- a/tests/test_on_this_day.py
+++ b/tests/test_on_this_day.py
@@ -216,7 +216,7 @@ class TestOnThisDayPage(AppTestCase):
         # Re-fetch the user to ensure it's bound to the current session
         # and available for login and content creation.
         with self.app.app_context():
-            self.no_otd_content_user = User.query.get(no_otd_content_user_id)
+            self.no_otd_content_user = self.db.session.get(User, no_otd_content_user_id)
 
         # Corrected: Ensure content is created with the fetched user's ID
         # self.fixed_today is datetime(2023, 10, 26, 12, 0, 0)
@@ -296,7 +296,7 @@ class TestOnThisDayPage(AppTestCase):
             wrong_day_user_id = wrong_day_user.id
 
         with self.app.app_context():
-            self.wrong_day_user = User.query.get(wrong_day_user_id)
+            self.wrong_day_user = self.db.session.get(User, wrong_day_user_id)
 
         # Create a post by this user from a previous year but a different day/month
         # self.fixed_today is datetime(2023, 10, 26, 12, 0, 0)

--- a/tests/test_recommendation_api.py
+++ b/tests/test_recommendation_api.py
@@ -246,8 +246,8 @@ class TestRecommendationAPI(AppTestCase):
         # 3. user2 joins this group
         # Need to fetch user2 and group_by_user3 as ORM objects to append to relationship
         with self.app.app_context(): # Add app context here
-            user2 = User.query.get(self.user2_id)
-            # group_obj = Group.query.get(group_by_user3.id) # _create_db_group should return the object
+            user2 = self.db.session.get(User, self.user2_id)
+            # group_obj = self.db.session.get(Group, group_by_user3.id) # _create_db_group should return the object
             group_by_user3_merged = self.db.session.merge(group_by_user3) # Ensure group is in session
 
             if user2 and group_by_user3_merged:

--- a/tests/test_series_feature.py
+++ b/tests/test_series_feature.py
@@ -70,7 +70,7 @@ class TestSeriesFeature(AppTestCase):
             db.session.add(original_series_obj) # Add to current session
             series_id = original_series_obj.id # Now access ID
             self.assertIsNotNone(series_id, "Series ID should be populated.")
-            series = Series.query.get(series_id)
+            series = self.db.session.get(Series, series_id)
             self.assertIsNotNone(series, "Series should exist after creation and fetching.")
 
             post1_title = "Post 1 for Cascade Test"
@@ -80,14 +80,14 @@ class TestSeriesFeature(AppTestCase):
             db.session.add(original_post1_obj) # Add to current session
             post1_id = original_post1_obj.id # Now access ID
             self.assertIsNotNone(post1_id, "Post1 ID should be populated.")
-            post1 = Post.query.get(post1_id)
+            post1 = self.db.session.get(Post, post1_id)
             self.assertIsNotNone(post1, "Post1 should exist after creation and fetching.")
 
             original_post2_obj = self._create_db_post(user_id=user.id, title=post2_title)
             db.session.add(original_post2_obj) # Add to current session
             post2_id = original_post2_obj.id # Now access ID
             self.assertIsNotNone(post2_id, "Post2 ID should be populated.")
-            post2 = Post.query.get(post2_id)
+            post2 = self.db.session.get(Post, post2_id)
             self.assertIsNotNone(post2, "Post2 should exist after creation and fetching.")
 
             # 2. Associate Posts with the Series using SeriesPost
@@ -115,7 +115,7 @@ class TestSeriesFeature(AppTestCase):
 
             # 4. Assertions
             # Assert Series is deleted
-            deleted_series = Series.query.get(series_id)
+            deleted_series = self.db.session.get(Series, series_id)
             self.assertIsNone(deleted_series, "Series should be deleted from the database.")
 
             # Assert SeriesPost entries are cascade deleted
@@ -124,8 +124,8 @@ class TestSeriesFeature(AppTestCase):
                              "SeriesPost entries should be cascade deleted.")
 
             # Assert original Posts still exist
-            self.assertIsNotNone(Post.query.get(post1_id), "Post1 should still exist after series deletion.")
-            self.assertIsNotNone(Post.query.get(post2_id), "Post2 should still exist after series deletion.")
+            self.assertIsNotNone(self.db.session.get(Post, post1_id), "Post1 should still exist after series deletion.")
+            self.assertIsNotNone(self.db.session.get(Post, post2_id), "Post2 should still exist after series deletion.")
 
     @unittest.skip("Placeholder test")
     def test_cascade_delete_post_to_series_post(self):


### PR DESCRIPTION
Replaced instances of SQLAlchemy's legacy `Query.get()` method with the recommended `Session.get()` for compatibility with SQLAlchemy 2.0.

This addresses the `LegacyAPIWarning`. Most direct usages of `<Model>.query.get()` and `db.session.query(<Model>).get()` have been updated to `db.session.get(<Model>, <id>)`.

Note: One test (`test_user_feed_api.py::test_get_feed_empty_for_new_user_no_relevant_content`) is still failing. This appears to be an issue with user retrieval within the test context for that specific API endpoint, rather than a direct consequence of the `Query.get` replacement in general application code.