### PR TITLE
Fix: Ensure Socket.IO handlers receive user session in tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,6 +122,9 @@ app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///site.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)
 migrate.init_app(app, db)
+app.config["SECRET_KEY"] = "supersecretkey" # Moved Up
+app.config["JWT_SECRET_KEY"] = "your-jwt-secret-key"  # Moved Up
+
 socketio = SocketIO(app)
 api = Api(app)
 jwt = JWTManager(app)
@@ -1741,6 +1744,7 @@ def chat_page():
 # Chat SocketIO Handlers
 @socketio.on('join_chat_room')
 def handle_join_chat_room_event(data):
+    print(f"SOCKETIO DEBUG (direct print): session in handle_join_chat_room_event: {dict(session)}", flush=True)
     room_name = data.get('room_name') # e.g., "chat_room_1"
     user_id = session.get('user_id')
     username = session.get('username', 'Anonymous')


### PR DESCRIPTION
- Modified `app.py` to set `SECRET_KEY` before SocketIO initialization.
- Standardized `SERVER_NAME` to 'localhost' in `test_base.py`.
- Updated `AppTestCase.login` to ensure Socket.IO client reconnects and picks up the session, resolving `user_id is None` issues.

Feat: Add test for sending message to unjoined chat room

- Added `test_send_message_to_unjoined_room` to `test_chat.py`.

Known Issue:
- Socket.IO tests involving `join_room` (e.g., `test_socketio_join_and_send_message` and parts of the new test) are failing with `ValueError: sid is not connected to requested namespace`. This issue persists despite troubleshooting and requires further investigation.