### PR TITLE
Fix: Add scripts block to base.html for template inheritance

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -368,5 +368,6 @@
             });
         })();
     </script>
+    {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
This resolves a Jinja2 TemplateSyntaxError that occurred because the blog.html template was trying to define a 'scripts' block that did not exist in the parent base.html template.

Adding the block to base.html allows child templates to correctly inject their specific JavaScript.