### PR TITLE
feat: Add 21 new model and API tests

### DIFF
--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,98 @@
+import unittest
+import json
+from flask_jwt_extended import create_access_token
+
+from app import db
+from models import User, ChatRoom, ChatMessage # Correctly import ChatMessage
+from tests.test_base import AppTestCase # Assuming this sets up app context and db
+
+class TestChatAPI(AppTestCase):
+
+    def setUp(self):
+        super().setUp() # Call AppTestCase.setUp
+        with self.app.app_context():
+            # User for authentication
+            self.api_user = self._create_db_user(username="chat_api_user", password="password")
+            self.access_token = create_access_token(identity=self.api_user.id)
+            self.auth_headers = {"Authorization": f"Bearer {self.access_token}"}
+
+            # Common chat room for tests
+            self.test_room = self._create_db_chat_room(name="General Chat Room", creator_id=self.api_user.id)
+
+            # Add some messages to the room for pagination tests
+            for i in range(25): # Create 25 messages
+                msg = ChatMessage(
+                    room_id=self.test_room.id,
+                    user_id=self.api_user.id,
+                    message=f"Message {i}"
+                )
+                db.session.add(msg)
+            db.session.commit()
+
+    def _create_db_chat_room(self, name, creator_id=None):
+        # Helper specific to this test file, if not using one from AppTestCase or if customization is needed
+        room = ChatRoom(name=name, creator_id=creator_id)
+        db.session.add(room)
+        db.session.commit()
+        return db.session.get(ChatRoom, room.id) # Return the managed object
+
+    def test_get_chat_room_messages_invalid_room_id(self):
+        with self.app.app_context():
+            invalid_room_id = 99999
+            response = self.client.get(f'/api/chat/rooms/{invalid_room_id}/messages', headers=self.auth_headers)
+            self.assertEqual(response.status_code, 404)
+            data = response.get_json()
+            self.assertIn("Chat room not found", data["message"])
+
+    def test_get_chat_room_messages_pagination(self):
+        with self.app.app_context():
+            # Test first page
+            response_page1 = self.client.get(f'/api/chat/rooms/{self.test_room.id}/messages?page=1&per_page=10', headers=self.auth_headers)
+            self.assertEqual(response_page1.status_code, 200)
+            data_page1 = response_page1.get_json()
+
+            self.assertEqual(data_page1["room_id"], self.test_room.id)
+            self.assertEqual(len(data_page1["messages"]), 10)
+            self.assertEqual(data_page1["page"], 1)
+            self.assertEqual(data_page1["per_page"], 10)
+            self.assertEqual(data_page1["total_messages"], 25)
+            self.assertEqual(data_page1["total_pages"], 3) # 25 messages, 10 per page = 3 pages
+
+            # Messages are ordered by timestamp desc in API, so Message 24 should be first on page 1
+            self.assertEqual(data_page1["messages"][0]["message"], "Message 24")
+
+            # Test second page
+            response_page2 = self.client.get(f'/api/chat/rooms/{self.test_room.id}/messages?page=2&per_page=10', headers=self.auth_headers)
+            self.assertEqual(response_page2.status_code, 200)
+            data_page2 = response_page2.get_json()
+
+            self.assertEqual(len(data_page2["messages"]), 10)
+            self.assertEqual(data_page2["page"], 2)
+            # Message 14 should be first on page 2 (messages 24-15 on page 1, 14-5 on page 2)
+            self.assertEqual(data_page2["messages"][0]["message"], "Message 14")
+
+            # Test last page (should have remaining 5 messages)
+            response_page3 = self.client.get(f'/api/chat/rooms/{self.test_room.id}/messages?page=3&per_page=10', headers=self.auth_headers)
+            self.assertEqual(response_page3.status_code, 200)
+            data_page3 = response_page3.get_json()
+
+            self.assertEqual(len(data_page3["messages"]), 5)
+            self.assertEqual(data_page3["page"], 3)
+            # Message 4 should be first on page 3
+            self.assertEqual(data_page3["messages"][0]["message"], "Message 4")
+
+    def test_get_chat_room_messages_default_pagination(self):
+        with self.app.app_context():
+            # Test default pagination (per_page=20 as per API implementation)
+            response = self.client.get(f'/api/chat/rooms/{self.test_room.id}/messages', headers=self.auth_headers)
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()
+
+            self.assertEqual(len(data["messages"]), 20) # Default per_page is 20
+            self.assertEqual(data["page"], 1)
+            self.assertEqual(data["per_page"], 20)
+            self.assertEqual(data["total_messages"], 25)
+            self.assertEqual(data["total_pages"], 2) # 25 messages, 20 per page = 2 pages
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_model.py
+++ b/tests/test_chat_model.py
@@ -1,0 +1,73 @@
+import unittest
+from datetime import datetime, timezone
+from app import db
+from models import User, ChatRoom, ChatMessage
+from tests.test_base import AppTestCase
+
+class TestChatModel(AppTestCase):
+
+    def test_chat_room_repr(self):
+        with self.app.app_context():
+            room = ChatRoom(name="Chat Room Repr Test")
+            db.session.add(room)
+            db.session.commit()
+            self.assertEqual(repr(room), "<ChatRoom Chat Room Repr Test>")
+
+    def test_chat_message_repr(self):
+        with self.app.app_context():
+            user = self._create_db_user(username="chat_msg_user_repr")
+            room = self._create_db_chat_room(name="Chat Msg Repr Room", creator_id=user.id)
+
+            msg_time = datetime.now(timezone.utc)
+            msg = ChatMessage(
+                room_id=room.id,
+                user_id=user.id,
+                message="Hello repr world",
+                timestamp=msg_time
+            )
+            db.session.add(msg)
+            db.session.commit()
+            # The repr includes the timestamp, which can be tricky for exact match.
+            # We'll check the static parts.
+            self.assertTrue(repr(msg).startswith(f"<ChatMessage User {user.id} in Room {room.id} at"))
+
+    def test_chat_message_to_dict(self):
+        with self.app.app_context():
+            user = self._create_db_user(username="chat_msg_user_dict")
+            room = self._create_db_chat_room(name="Chat Msg Dict Room", creator_id=user.id)
+
+            msg_content = "This is a test message for to_dict."
+            msg_time = datetime.now(timezone.utc) # Approximate
+
+            chat_msg = ChatMessage(
+                room_id=room.id,
+                user_id=user.id,
+                message=msg_content,
+                timestamp=msg_time
+            )
+            db.session.add(chat_msg)
+            db.session.commit()
+
+            # Re-fetch to ensure all attributes are loaded correctly
+            fetched_msg = db.session.get(ChatMessage, chat_msg.id)
+
+            expected_dict = {
+                "id": fetched_msg.id,
+                "room_id": room.id,
+                "user_id": user.id,
+                "username": user.username,
+                "message": msg_content,
+                "timestamp": fetched_msg.timestamp.isoformat() # Use actual DB value
+            }
+            self.assertDictEqual(fetched_msg.to_dict(), expected_dict)
+
+    def _create_db_chat_room(self, name, creator_id=None):
+        # Helper to create chat rooms consistently for chat model tests
+        room = ChatRoom(name=name, creator_id=creator_id)
+        db.session.add(room)
+        db.session.commit()
+        return db.session.get(ChatRoom, room.id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_group_model.py
+++ b/tests/test_group_model.py
@@ -1,0 +1,100 @@
+import unittest
+from datetime import datetime, timezone
+from app import db
+from models import User, Group
+from tests.test_base import AppTestCase
+
+class TestGroupModel(AppTestCase):
+
+    def test_group_repr(self):
+        with self.app.app_context():
+            creator = self._create_db_user(username="group_creator_repr")
+            group = Group(name="Represent Group", creator_id=creator.id)
+            db.session.add(group)
+            db.session.commit()
+            self.assertEqual(repr(group), "<Group 'Represent Group'>")
+
+    def test_add_member_to_group(self):
+        with self.app.app_context():
+            creator = self._create_db_user(username="group_creator_add")
+            member = self._create_db_user(username="group_member_add")
+            group = self._create_db_group(creator_id=creator.id, name="Group For Adding Members")
+
+            group.members.append(member)
+            db.session.commit()
+
+            # Re-fetch group and member to ensure session state is current
+            group = db.session.get(Group, group.id)
+            member = db.session.get(User, member.id)
+
+            self.assertIn(member, group.members)
+            self.assertIn(group, member.joined_groups)
+
+    def test_remove_member_from_group(self):
+        with self.app.app_context():
+            creator = self._create_db_user(username="group_creator_remove")
+            member = self._create_db_user(username="group_member_remove")
+            group = self._create_db_group(creator_id=creator.id, name="Group For Removing Members")
+
+            group.members.append(member)
+            db.session.commit()
+
+            # Re-fetch to ensure relationship is loaded
+            group = db.session.get(Group, group.id)
+            self.assertIn(member, group.members)
+
+            group.members.remove(member)
+            db.session.commit()
+
+            # Re-fetch group and member
+            group = db.session.get(Group, group.id)
+            member = db.session.get(User, member.id)
+
+            self.assertNotIn(member, group.members)
+            self.assertNotIn(group, member.joined_groups)
+
+    def test_group_to_dict(self):
+        with self.app.app_context():
+            creator = self._create_db_user(username="group_creator_dict")
+            group_description = "A test description for dict."
+            created_time = datetime.now(timezone.utc) # Approximate, exact match difficult
+
+            group = Group(
+                name="Dict Group",
+                creator_id=creator.id,
+                description=group_description,
+                created_at=created_time
+            )
+            db.session.add(group)
+            db.session.commit()
+
+            # Re-fetch to ensure all attributes are loaded correctly, especially defaults or server-side changes
+            group_fetched = db.session.get(Group, group.id)
+
+            expected_dict = {
+                "id": group_fetched.id,
+                "name": "Dict Group",
+                "description": group_description,
+                "creator_id": creator.id,
+                "created_at": group_fetched.created_at.isoformat(), # Use the actual DB value
+                "creator_username": creator.username,
+            }
+            self.assertDictEqual(group_fetched.to_dict(), expected_dict)
+
+    def test_group_creator_relationship(self):
+        with self.app.app_context():
+            creator = self._create_db_user(username="group_rel_creator")
+            group = self._create_db_group(creator_id=creator.id, name="Creator Test Group")
+
+            # Re-fetch group
+            group_fetched = db.session.get(Group, group.id)
+            self.assertIsNotNone(group_fetched.creator)
+            self.assertEqual(group_fetched.creator.id, creator.id)
+            self.assertEqual(group_fetched.creator.username, "group_rel_creator")
+
+            # Check back-population
+            creator_fetched = db.session.get(User, creator.id)
+            self.assertIn(group_fetched, creator_fetched.created_groups)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added a total of 21 new tests to improve coverage:

Model Tests (14 new):
- User model:
  - test_user_get_stats
  - test_user_get_current_status
- Group model (in new tests/test_group_model.py):
  - test_group_repr
  - test_add_member_to_group
  - test_remove_member_from_group
  - test_group_to_dict
  - test_group_creator_relationship
- EventRSVP model:
  - test_event_rsvp_unique_constraint
- PollVote model:
  - test_poll_vote_unique_constraint
- Series model:
  - test_series_to_dict_with_posts
  - test_add_post_to_series_property
- Chat models (in new tests/test_chat_model.py):
  - test_chat_room_repr
  - test_chat_message_repr
  - test_chat_message_to_dict

API Tests (7 new):
- Chat API (in new tests/test_chat_api.py):
  - test_get_chat_room_messages_invalid_room_id
  - test_get_chat_room_messages_pagination
  - test_get_chat_room_messages_default_pagination
- Comment API:
  - test_post_comment_to_non_existent_post
  - test_post_comment_when_blocked_by_author
- SharedFile API:
  - test_delete_shared_file_unauthorized_user
  - test_delete_non_existent_shared_file_record

Skipped planned User Block API tests as the API endpoints do not currently exist. All new test files follow existing structure and utilize AppTestCase helpers. Reviewed tests for clarity, correctness, and consistency.