### PR TITLE
Fix chat API tests related to JWT identity and pagination order

### DIFF
--- a/api.py
+++ b/api.py
@@ -979,7 +979,7 @@ class ChatRoomMessagesResource(Resource):
         )  # Default 20 messages per page
 
         messages_query = ChatMessage.query.filter_by(room_id=room_id).order_by(
-            ChatMessage.timestamp.desc()
+            ChatMessage.timestamp.desc(), ChatMessage.id.desc()
         )
         paginated_messages = messages_query.paginate(
             page=page, per_page=per_page, error_out=False

--- a/static/profile_pics/2806a7d6511a4f40894ced93f1cffce9_test_profile.png
+++ b/static/profile_pics/2806a7d6511a4f40894ced93f1cffce9_test_profile.png
@@ -1,0 +1,1 @@
+dummy_image_content_for_test_profile_pic_update

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -13,7 +13,7 @@ class TestChatAPI(AppTestCase):
         with self.app.app_context():
             # User for authentication
             self.api_user = self._create_db_user(username="chat_api_user", password="password")
-            self.access_token = create_access_token(identity=self.api_user.id)
+            self.access_token = create_access_token(identity=str(self.api_user.id)) # Use string identity
             self.auth_headers = {"Authorization": f"Bearer {self.access_token}"}
 
             # Common chat room for tests


### PR DESCRIPTION
- Corrected JWT identity type in TestChatAPI to use string IDs, resolving 422 errors in chat message retrieval tests.
- Added secondary sort criterion (ChatMessage.id.desc()) to the chat message API query to ensure stable pagination order when timestamps are identical.