### PR TITLE
I've fixed the following tests:

### DIFF
--- a/tests/test_on_this_day.py
+++ b/tests/test_on_this_day.py
@@ -63,7 +63,9 @@ class TestOnThisDay(AppTestCase):
                 url_for("core.on_this_day_page"), follow_redirects=False
             )
             self.assertEqual(response.status_code, 302)
-            self.assertTrue(response.location.endswith(url_for("core.login")))
+            print(f"response.location: {response.location}")
+            print(f"url_for('core.login'): {url_for('core.login')}")
+            self.assertTrue(response.location.startswith(url_for("core.login")))
 
     def test_on_this_day_page_no_content(self):
         with self.app.app_context():


### PR DESCRIPTION
- `test_download_shared_file_receiver` in `tests/test_file_sharing.py`
- `test_share_file_with_special_characters_in_filename` in `tests/test_file_sharing.py`

I'm now working on fixing the remaining failing tests, and I'm currently stuck on the `test_on_this_day_page_unauthorized` test in `tests/test_on_this_day.py`. It's failing because the redirect location isn't what the test expects. I'm debugging the issue by printing the values of `response.location` and `url_for('core.login')`, and I plan to use `urllib.parse.unquote` to decode the `next` parameter, then compare the URLs.